### PR TITLE
feat(frontend): Implement Privacy Mode (FR3.4)

### DIFF
--- a/docs/features/FR3.4_privacy_mode.md
+++ b/docs/features/FR3.4_privacy_mode.md
@@ -3,7 +3,7 @@
 **Feature ID:** FR3.4
 **Title:** Privacy Mode
 **User Story:** As a user, I want to be able to quickly hide all monetary values in the application with a single click, so that I can show my portfolio structure to others without revealing sensitive financial details.
-**Status:** 📝 Planned
+**Status:** ✅ Implemented
 
 ---
 

--- a/docs/workflow_history.md
+++ b/docs/workflow_history.md
@@ -6,6 +6,36 @@ Its purpose is to build an experience history that can be used as a reference fo
 
 ---
 
+## 2025-09-02: Implement Privacy Mode (FR3.4)
+
+*   **Task Description:** Implement a "Privacy Mode" feature that allows users to obscure sensitive monetary values across the application with a single toggle.
+
+*   **Key Prompts & Interactions:**
+    1.  **Initial Implementation:** The AI was prompted to implement the feature based on the plan. It correctly created a `PrivacyContext` and refactored the `formatCurrency` utility to use it.
+    2.  **User-led Course Correction:** The user provided critical feedback that the initial approach was too broad, hiding all monetary values including non-sensitive ones like individual stock prices.
+    3.  **Revised Plan & Refactoring:** A new plan was formulated to address the feedback. This involved:
+        *   Resetting all previous changes.
+        *   Creating a new, specific hook (`usePrivacySensitiveCurrency`).
+        *   Selectively applying this hook *only* to high-level summary components (`SummaryCard`, `PortfolioSummary`, etc.) while leaving others untouched.
+    4.  **E2E Test Correction:** The E2E test was updated to verify the new, correct behavior: asserting that summary values are hidden while table values remain visible in privacy mode.
+
+*   **File Changes:**
+    *   `frontend/src/context/PrivacyContext.tsx`: **New** file to manage the global privacy state.
+    *   `frontend/src/utils/formatting.ts`: **Updated** to add the `usePrivacySensitiveCurrency` hook.
+    *   `frontend/src/pages/DashboardPage.tsx`: **Updated** to add the UI toggle.
+    *   `frontend/src/components/Dashboard/SummaryCard.tsx`, `frontend/src/components/Portfolio/PortfolioSummary.tsx`, `frontend/src/components/Goals/...`: **Updated** to use the new selective hook.
+    *   `e2e/tests/privacy-mode.spec.ts`: **New** E2E test to validate the selective obscuring.
+    *   `frontend/src/__tests__/`: **New** unit tests for the context and hook.
+    *   `docs/features/FR3.4_privacy_mode.md`: **Updated** status to "Implemented".
+
+*   **Verification:**
+    - The full test suite will be run before submission.
+
+*   **Outcome:**
+    - The "Privacy Mode" feature is implemented according to the refined user requirements. It correctly hides only high-level sensitive data, providing a better user experience. This task highlights the importance of clear requirements and iterative feedback in an AI-assisted workflow.
+
+---
+
 ## 2025-07-17: Backend for User Management
 
 *   **Task Description:** Implement the backend functionality for the User Management feature, allowing an administrator to perform CRUD operations on users.

--- a/e2e/tests/privacy-mode.spec.ts
+++ b/e2e/tests/privacy-mode.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+import { login } from '../utils';
+
+test.describe('Privacy Mode E2E Test', () => {
+  test.beforeEach(async ({ page }) => {
+    // Ensure local storage is clean before each test run
+    await page.context().clearCookies();
+    await page.goto('/');
+    await page.evaluate(() => localStorage.clear());
+    await login(page);
+    await page.goto('/dashboard');
+    // After login, clear privacy mode specifically to ensure a clean slate for each test
+    await page.evaluate(() => localStorage.removeItem('privacyMode'));
+    await page.reload();
+  });
+
+  test('should selectively hide sensitive data and persist the state', async ({ page }) => {
+    const privacyToggleShow = page.getByRole('button', { name: /hide sensitive data/i });
+    const privacyToggleHide = page.getByRole('button', { name: /show sensitive data/i });
+
+    // --- Locators ---
+    const totalValueCard = page.locator('.card', { hasText: 'Total Value' });
+    const sensitiveSummaryValue = totalValueCard.locator('p').last();
+
+    const topMoversTable = page.locator('table:has-text("Top Movers")');
+    const nonSensitivePriceValue = topMoversTable.locator('tbody >> tr').first().locator('td').nth(1);
+
+    // --- Regexes ---
+    const visibleValueRegex = /^-?₹[0-9,]+\.\d{2}$/;
+    const obscuredValue = '₹**,***.**';
+
+    // 1. VERIFY INITIAL STATE (everything visible)
+    await expect(sensitiveSummaryValue).toHaveText(visibleValueRegex);
+    await expect(nonSensitivePriceValue).toHaveText(visibleValueRegex);
+
+    // 2. TOGGLE PRIVACY MODE ON
+    await privacyToggleShow.click();
+
+    // 3. VERIFY SELECTIVE OBSCURING
+    // Sensitive value should be hidden
+    await expect(sensitiveSummaryValue).toHaveText(obscuredValue);
+    // Non-sensitive value should still be visible
+    await expect(nonSensitivePriceValue).toHaveText(visibleValueRegex);
+
+    // 4. RELOAD AND VERIFY PERSISTENCE
+    await page.reload();
+    await page.waitForSelector('.card:has-text("Total Value")'); // Ensure card is visible
+    // Sensitive value should still be hidden
+    await expect(sensitiveSummaryValue).toHaveText(obscuredValue);
+    // Non-sensitive value should still be visible
+    await expect(nonSensitivePriceValue).toHaveText(visibleValueRegex);
+
+    // 5. TOGGLE PRIVACY MODE OFF
+    await privacyToggleHide.click();
+
+    // 6. VERIFY VALUES ARE VISIBLE AGAIN
+    await expect(sensitiveSummaryValue).toHaveText(visibleValueRegex);
+    await expect(nonSensitivePriceValue).toHaveText(visibleValueRegex);
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,8 @@
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.60.0",
-        "react-router-dom": "^6.23.1"
+        "react-router-dom": "^6.23.1",
+        "react-select": "^5.8.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.28.0",
@@ -32,6 +33,7 @@
         "@types/node": "^24.2.1",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
+        "@types/react-select": "^5.0.1",
         "@typescript-eslint/eslint-plugin": "^7.15.0",
         "@typescript-eslint/parser": "^7.15.0",
         "@vitejs/plugin-react": "^4.2.1",
@@ -88,7 +90,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
@@ -141,7 +142,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
       "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
-      "dev": true,
       "dependencies": {
         "@babel/parser": "^7.28.0",
         "@babel/types": "^7.28.0",
@@ -239,7 +239,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -261,7 +260,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
       "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
-      "dev": true,
       "dependencies": {
         "@babel/traverse": "^7.27.1",
         "@babel/types": "^7.27.1"
@@ -359,7 +357,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -368,7 +365,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
       "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -413,7 +409,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
       "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.28.0"
       },
@@ -1828,7 +1823,6 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1837,7 +1831,6 @@
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
       "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/parser": "^7.27.2",
@@ -1851,7 +1844,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
       "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.0",
@@ -1869,7 +1861,6 @@
       "version": "7.28.1",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
       "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1"
@@ -2239,6 +2230,135 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -2689,6 +2809,31 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -3315,7 +3460,6 @@
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
       "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -3325,7 +3469,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -3333,14 +3476,12 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
-      "dev": true
+      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.29",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
       "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -4181,6 +4322,12 @@
         "undici-types": "~7.10.0"
       }
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
+    },
     "node_modules/@types/plist": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
@@ -4196,14 +4343,12 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4216,6 +4361,26 @@
       "dev": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-select": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-select/-/react-select-5.0.1.tgz",
+      "integrity": "sha512-h5Im0AP0dr4AVeHtrcvQrLV+gmPa7SA0AGdxl2jOhtwiE6KgXBFSogWw8az32/nusE6AQHlCOHQWjP1S/+oMWA==",
+      "deprecated": "This is a stub types definition. react-select provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-select": "*"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/responselike": {
@@ -5182,6 +5347,21 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
@@ -5747,7 +5927,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -6158,6 +6337,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/crc": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
@@ -6279,8 +6483,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/data-urls": {
       "version": "3.0.2",
@@ -6660,6 +6863,16 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/domexception": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
@@ -7036,7 +7249,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -7141,7 +7353,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -7752,6 +7963,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -8311,6 +8528,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -8493,7 +8725,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -8579,8 +8810,7 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -8612,7 +8842,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -9848,7 +10077,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -9865,8 +10093,7 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -10023,8 +10250,7 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -10283,6 +10509,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -10870,7 +11102,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11038,7 +11269,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -11050,7 +11280,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -11106,8 +11335,7 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
@@ -11137,7 +11365,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -11167,8 +11394,7 @@
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -11531,6 +11757,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -11715,6 +11958,43 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-select": {
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.10.2.tgz",
+      "integrity": "sha512-Z33nHdEFWq9tfnfVXaiM12rbJmk+QjFEztWLtmXqQhz6Al4UZZ9xc0wiatmGtUOCCnHN0WizL3tCMYRENX4rVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "@emotion/cache": "^11.4.0",
+        "@emotion/react": "^11.8.1",
+        "@floating-ui/dom": "^1.0.1",
+        "@types/react-transition-group": "^4.4.0",
+        "memoize-one": "^6.0.0",
+        "prop-types": "^15.6.0",
+        "react-transition-group": "^4.3.0",
+        "use-isomorphic-layout-effect": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/read-binary-file-arch": {
@@ -11908,7 +12188,6 @@
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
@@ -11956,7 +12235,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -12585,6 +12863,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
@@ -12658,7 +12942,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -13222,6 +13505,20 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/utf8-byte-length": {

--- a/frontend/src/__tests__/context/PrivacyContext.test.tsx
+++ b/frontend/src/__tests__/context/PrivacyContext.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, act, within } from '@testing-library/react';
+import { PrivacyProvider, usePrivacy } from '../../context/PrivacyContext';
+import React from 'react';
+
+const TestComponent = () => {
+  const { isPrivacyMode, togglePrivacyMode } = usePrivacy();
+  return (
+    <div>
+      <span data-testid="privacy-mode">{isPrivacyMode.toString()}</span>
+      <button onClick={togglePrivacyMode}>Toggle</button>
+    </div>
+  );
+};
+
+describe('PrivacyContext', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('should initialize with privacy mode off by default', () => {
+    render(
+      <PrivacyProvider>
+        <TestComponent />
+      </PrivacyProvider>
+    );
+    expect(within(screen.getByTestId('privacy-mode')).getByText('false')).toBeInTheDocument();
+  });
+
+  it('should initialize with the value from localStorage if present', () => {
+    localStorage.setItem('privacyMode', 'true');
+    render(
+      <PrivacyProvider>
+        <TestComponent />
+      </PrivacyProvider>
+    );
+    expect(within(screen.getByTestId('privacy-mode')).getByText('true')).toBeInTheDocument();
+  });
+
+  it('should toggle privacy mode and update localStorage', () => {
+    render(
+      <PrivacyProvider>
+        <TestComponent />
+      </PrivacyProvider>
+    );
+
+    const toggleButton = screen.getByText('Toggle');
+
+    // Initial state
+    expect(within(screen.getByTestId('privacy-mode')).getByText('false')).toBeInTheDocument();
+    expect(localStorage.getItem('privacyMode')).toBe('false');
+
+    // Toggle on
+    act(() => {
+      toggleButton.click();
+    });
+    expect(within(screen.getByTestId('privacy-mode')).getByText('true')).toBeInTheDocument();
+    expect(localStorage.getItem('privacyMode')).toBe('true');
+
+    // Toggle off
+    act(() => {
+      toggleButton.click();
+    });
+    expect(within(screen.getByTestId('privacy-mode')).getByText('false')).toBeInTheDocument();
+    expect(localStorage.getItem('privacyMode')).toBe('false');
+  });
+});

--- a/frontend/src/__tests__/hooks/usePrivacySensitiveCurrency.test.ts
+++ b/frontend/src/__tests__/hooks/usePrivacySensitiveCurrency.test.ts
@@ -1,0 +1,31 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { usePrivacySensitiveCurrency, formatCurrency as originalFormatCurrency } from '../../utils/formatting';
+import * as PrivacyContext from '../../context/PrivacyContext';
+
+describe('usePrivacySensitiveCurrency', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should return the real currency string when privacy mode is off', () => {
+    jest.spyOn(PrivacyContext, 'usePrivacy').mockReturnValue({
+      isPrivacyMode: false,
+      togglePrivacyMode: () => {},
+    });
+
+    const { result } = renderHook(() => usePrivacySensitiveCurrency());
+    const formatCurrency = result.current;
+    expect(formatCurrency(123456.78)).toBe(originalFormatCurrency(123456.78));
+  });
+
+  it('should return the obscured placeholder string when privacy mode is on', () => {
+    jest.spyOn(PrivacyContext, 'usePrivacy').mockReturnValue({
+      isPrivacyMode: true,
+      togglePrivacyMode: () => {},
+    });
+
+    const { result } = renderHook(() => usePrivacySensitiveCurrency());
+    const formatCurrency = result.current;
+    expect(formatCurrency(123456.78)).toBe('₹**,***.**');
+  });
+});

--- a/frontend/src/components/Dashboard/SummaryCard.tsx
+++ b/frontend/src/components/Dashboard/SummaryCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { formatCurrency } from '../../utils/formatting';
+import { usePrivacySensitiveCurrency } from '../../utils/formatting';
 
 interface SummaryCardProps {
     title: string;
@@ -8,6 +8,7 @@ interface SummaryCardProps {
 }
 
 const SummaryCard: React.FC<SummaryCardProps> = ({ title, value, isPnl = false }) => {
+    const formatCurrency = usePrivacySensitiveCurrency();
     const getPnlColor = (pnlValue: number) => {
         if (pnlValue > 0) return 'text-green-600';
         if (pnlValue < 0) return 'text-red-600';

--- a/frontend/src/components/Goals/GoalCard.tsx
+++ b/frontend/src/components/Goals/GoalCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Goal } from '../../types/goal';
-import { formatCurrency, formatDate } from '../../utils/formatting';
+import { usePrivacySensitiveCurrency, formatDate } from '../../utils/formatting';
 
 interface GoalCardProps {
   goal: Goal;
@@ -10,6 +10,7 @@ interface GoalCardProps {
 }
 
 const GoalCard: React.FC<GoalCardProps> = ({ goal, onEdit, onDelete, onSelect }) => {
+  const formatCurrency = usePrivacySensitiveCurrency();
   return (
     <div className="card bg-base-100 shadow-xl">
       <div className="card-body">

--- a/frontend/src/components/Goals/GoalDetailView.tsx
+++ b/frontend/src/components/Goals/GoalDetailView.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useGoal, useCreateGoalLink, useDeleteGoalLink } from '../../hooks/useGoals';
 import AssetLinkModal from '../modals/AssetLinkModal';
-import { formatCurrency, formatDate } from '../../utils/formatting';
+import { usePrivacySensitiveCurrency, formatDate } from '../../utils/formatting';
 import { TrashIcon, LinkIcon } from '@heroicons/react/24/outline';
 
 interface GoalDetailViewProps {
@@ -30,6 +30,7 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({ goalId }) => {
   const [isLinkModalOpen, setIsLinkModalOpen] = useState(false);
   const createGoalLink = useCreateGoalLink();
   const deleteGoalLink = useDeleteGoalLink();
+  const formatCurrency = usePrivacySensitiveCurrency();
 
   const handleLink = (linkData: { portfolio_id?: string; asset_id?: string }) => {
     createGoalLink.mutate({ goalId, link: { ...linkData, goal_id: goalId } });

--- a/frontend/src/components/Goals/GoalList.tsx
+++ b/frontend/src/components/Goals/GoalList.tsx
@@ -5,7 +5,7 @@ import { useDeleteGoal } from '../../hooks/useGoals';
 import DeleteGoalModal from './DeleteGoalModal';
 import { TrashIcon } from '@heroicons/react/24/outline';
 import { useQueryClient } from '@tanstack/react-query';
-import { formatCurrency, formatDate } from '../../utils/formatting';
+import { usePrivacySensitiveCurrency, formatDate } from '../../utils/formatting';
 
 interface GoalListProps {
   goals: Goal[];
@@ -16,6 +16,7 @@ const GoalList: React.FC<GoalListProps> = ({ goals }) => {
   const [isModalOpen, setModalOpen] = useState(false);
   const [goalToDelete, setGoalToDelete] = useState<Goal | null>(null);
   const deleteGoalMutation = useDeleteGoal();
+  const formatCurrency = usePrivacySensitiveCurrency();
 
   const handleDeleteClick = (goal: Goal) => {
     setGoalToDelete(goal);

--- a/frontend/src/components/Portfolio/HoldingDetailModal.tsx
+++ b/frontend/src/components/Portfolio/HoldingDetailModal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Holding } from '../../types/holding';
 import { Transaction } from '../../types/portfolio';
 import { useAssetAnalytics, useAssetTransactions } from '../../hooks/usePortfolios';
-import { formatCurrency, formatDate, formatPercentage } from '../../utils/formatting';
+import { usePrivacySensitiveCurrency, formatCurrency, formatDate, formatPercentage } from '../../utils/formatting';
 import { PencilSquareIcon, TrashIcon } from '@heroicons/react/24/outline';
 
 interface HoldingDetailModalProps {
@@ -73,6 +73,7 @@ const HoldingDetailModal: React.FC<HoldingDetailModalProps> = ({ holding, portfo
         holding.asset_id,
         { enabled: !!holding.asset_id }
     );
+    const formatSensitiveCurrency = usePrivacySensitiveCurrency();
 
     return (
         <div className="modal-overlay" onClick={onClose}>
@@ -96,16 +97,16 @@ const HoldingDetailModal: React.FC<HoldingDetailModalProps> = ({ holding, portfo
                     </div>
                     <div data-testid="summary-avg-buy-price">
                         <p className="text-sm text-gray-500">Avg. Buy Price</p>
-                        <p className="font-semibold">{formatCurrency(holding.average_buy_price)}</p>
+                        <p className="font-semibold">{formatSensitiveCurrency(holding.average_buy_price)}</p>
                     </div>
                     <div data-testid="summary-current-value">
                         <p className="text-sm text-gray-500">Current Value</p>
-                        <p className="font-semibold">{formatCurrency(holding.current_value)}</p>
+                        <p className="font-semibold">{formatSensitiveCurrency(holding.current_value)}</p>
                     </div>
                     <div data-testid="summary-unrealized-pnl">
                         <p className="text-sm text-gray-500">Unrealized P&L</p>
                         <p className={`font-semibold ${holding.unrealized_pnl >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                            {formatCurrency(holding.unrealized_pnl)}
+                            {formatSensitiveCurrency(holding.unrealized_pnl)}
                         </p>
                     </div>
                     <div data-testid="summary-realized-xirr">

--- a/frontend/src/components/Portfolio/PortfolioSummary.tsx
+++ b/frontend/src/components/Portfolio/PortfolioSummary.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PortfolioSummary as PortfolioSummaryType } from '../../types/holding';
-import { formatCurrency } from '../../utils/formatting';
+import { usePrivacySensitiveCurrency } from '../../utils/formatting';
 
 interface SummaryItemProps {
     label: string;
@@ -9,6 +9,7 @@ interface SummaryItemProps {
 }
 
 const SummaryItem: React.FC<SummaryItemProps> = ({ label, value, isPnl = false }) => {
+    const formatCurrency = usePrivacySensitiveCurrency();
     const getPnlColor = (pnl: number) => {
         if (pnl > 0) return 'text-green-600';
         if (pnl < 0) return 'text-red-600';

--- a/frontend/src/context/PrivacyContext.tsx
+++ b/frontend/src/context/PrivacyContext.tsx
@@ -1,0 +1,61 @@
+import React, { createContext, useState, useContext, useEffect, useMemo, ReactNode } from 'react';
+
+// Define the shape of the context state
+interface PrivacyContextState {
+  isPrivacyMode: boolean;
+  togglePrivacyMode: () => void;
+}
+
+// Create the context with a default value
+const PrivacyContext = createContext<PrivacyContextState | undefined>(undefined);
+
+// Define the props for the provider
+interface PrivacyProviderProps {
+  children: ReactNode;
+}
+
+// Create the provider component
+export const PrivacyProvider: React.FC<PrivacyProviderProps> = ({ children }) => {
+  const [isPrivacyMode, setIsPrivacyMode] = useState<boolean>(() => {
+    try {
+      const item = window.localStorage.getItem('privacyMode');
+      return item ? JSON.parse(item) : false;
+    } catch (error) {
+      console.error("Error reading from localStorage", error);
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem('privacyMode', JSON.stringify(isPrivacyMode));
+    } catch (error) {
+      console.error("Error writing to localStorage", error);
+    }
+  }, [isPrivacyMode]);
+
+  const togglePrivacyMode = () => {
+    setIsPrivacyMode(prevMode => !prevMode);
+  };
+
+  const contextValue = useMemo(() => ({
+    isPrivacyMode,
+    togglePrivacyMode,
+  }), [isPrivacyMode]);
+
+  return (
+    <PrivacyContext.Provider value={contextValue}>
+      {children}
+    </PrivacyContext.Provider>
+  );
+};
+
+// Create a custom hook to use the privacy context
+// eslint-disable-next-line react-refresh/only-export-components
+export const usePrivacy = (): PrivacyContextState => {
+  const context = useContext(PrivacyContext);
+  if (context === undefined) {
+    throw new Error('usePrivacy must be used within a PrivacyProvider');
+  }
+  return context;
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { HashRouter as Router } from 'react-router-dom';
 import App from './App.tsx';
 import './index.css';
 import { AuthProvider } from './context/AuthContext';
+import { PrivacyProvider } from './context/PrivacyContext';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const queryClient = new QueryClient();
@@ -13,7 +14,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <QueryClientProvider client={queryClient}>
       <Router>
         <AuthProvider>
-          <App />
+          <PrivacyProvider>
+            <App />
+          </PrivacyProvider>
         </AuthProvider>
       </Router>
     </QueryClientProvider>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -4,10 +4,13 @@ import TopMoversTable from '../components/Dashboard/TopMoversTable';
 import PortfolioHistoryChart from '../components/Dashboard/PortfolioHistoryChart';
 import AssetAllocationChart from '../components/Dashboard/AssetAllocationChart';
 import HelpLink from '../components/HelpLink';
+import { usePrivacy } from '../context/PrivacyContext';
+import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
 
 
 const DashboardPage = () => {
   const { data: summary, isLoading, isError } = useDashboardSummary();
+  const { isPrivacyMode, togglePrivacyMode } = usePrivacy();
 
   if (isLoading) {
     return <div className="text-center p-8">Loading dashboard data...</div>;
@@ -19,9 +22,22 @@ const DashboardPage = () => {
 
   return (
     <div className="space-y-8">
-      <div className="flex items-center">
-        <h1 className="text-3xl font-bold">Dashboard</h1>
-        <HelpLink sectionId="dashboard" />
+      <div className="flex justify-between items-center">
+        <div className="flex items-center">
+          <h1 className="text-3xl font-bold">Dashboard</h1>
+          <HelpLink sectionId="dashboard" />
+        </div>
+        <button
+          onClick={togglePrivacyMode}
+          className="p-2 rounded-full hover:bg-gray-200 transition-colors"
+          aria-label={isPrivacyMode ? 'Show sensitive data' : 'Hide sensitive data'}
+        >
+          {isPrivacyMode ? (
+            <EyeSlashIcon className="h-6 w-6 text-gray-600" />
+          ) : (
+            <EyeIcon className="h-6 w-6 text-gray-600" />
+          )}
+        </button>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">

--- a/frontend/src/utils/formatting.ts
+++ b/frontend/src/utils/formatting.ts
@@ -1,3 +1,5 @@
+import { usePrivacy } from '../context/PrivacyContext';
+
 export const formatCurrency = (value: number | string, currency = 'INR') => {
   const numericValue = Number(value);
   if (isNaN(numericValue) || value === null) {
@@ -27,4 +29,17 @@ export const formatPercentage = (value: number | undefined | null): string => {
     return 'N/A';
   }
   return `${(value * 100).toFixed(2)}%`;
+};
+
+export const usePrivacySensitiveCurrency = () => {
+  const { isPrivacyMode } = usePrivacy();
+
+  const format = (value: number | string, currency = 'INR') => {
+    if (isPrivacyMode) {
+      return '₹**,***.**';
+    }
+    return formatCurrency(value, currency);
+  };
+
+  return format;
 };


### PR DESCRIPTION
Implements a "Privacy Mode" feature that allows users to obscure sensitive monetary values across the application with a single toggle.

- Adds a `PrivacyContext` to manage the global state of the feature, persisted to `localStorage`.
- Introduces a `usePrivacySensitiveCurrency` hook to selectively format currency values that are considered sensitive.
- Adds a toggle button to the dashboard header to enable/disable the mode.
- Non-sensitive values, such as individual asset prices in tables, are not affected, per user feedback.
- Includes unit tests for the new context and hook.
- Includes a new E2E test to verify the selective obscuring of data.