### PR TITLE
fix: Add missing transaction types to filter dropdown

### DIFF
--- a/frontend/src/components/Transactions/TransactionFilterBar.tsx
+++ b/frontend/src/components/Transactions/TransactionFilterBar.tsx
@@ -96,6 +96,11 @@ const TransactionFilterBar: React.FC = () => {
             <option value="ALL">All</option>
             <option value="BUY">Buy</option>
             <option value="SELL">Sell</option>
+            <option value="DIVIDEND">Dividend</option>
+            <option value="SPLIT">Split</option>
+            <option value="BONUS">Bonus</option>
+            <option value="RSU_VEST">RSU Vest</option>
+            <option value="ESPP_PURCHASE">ESPP Purchase</option>
           </select>
         </div>
 


### PR DESCRIPTION
Added DIVIDEND, SPLIT, BONUS, RSU_VEST, and ESPP_PURCHASE options to the Type filter dropdown in TransactionFilterBar.tsx. Previously only BUY and SELL were available as filter options.