### PR TITLE
fix: Calculate Sharpe ratio per portfolio instead of combined (#160)

### DIFF
--- a/backend/app/crud/crud_analytics.py
+++ b/backend/app/crud/crud_analytics.py
@@ -518,7 +518,9 @@ class CRUDAnalytics:
             return 0.0
         user = portfolio.user
 
-        history_points = _get_portfolio_history(db=db, user=user, range_str="all")
+        history_points = _get_portfolio_history(
+            db=db, user=user, portfolio_id=portfolio_id, range_str="all"
+        )
         if len(history_points) < 2:
             logger.debug("Sharpe ratio: Not enough history points (<2).")
             return 0.0


### PR DESCRIPTION
## Summary

Fixes #160 - Sharpe ratio was returning the same value for all portfolios.

## Root Cause

The `_calculate_sharpe_ratio` function calls `_get_portfolio_history` which calculated history for **all user portfolios** combined instead of the specific portfolio.

## Changes

- **crud_dashboard.py**: Added optional `portfolio_id` parameter to `_get_portfolio_history`
  - Filter first transaction query by portfolio_id
  - Filter asset query by portfolio_id  
  - Filter transactions query by portfolio_id
  
- **crud_analytics.py**: Updated `_calculate_sharpe_ratio` to pass `portfolio_id` parameter

## Testing

All 11 analytics tests pass:
```
app/tests/api/v1/test_analytics.py ................................. [100%]
======= 11 passed =======
```

## Backward Compatibility

The `portfolio_id` parameter is optional with default `None`, so existing callers (dashboard history) continue to work unchanged.