### PR TITLE
fix(security): Add version pins for urllib3 and starlette vulnerabilities

### DIFF
--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -26,3 +26,7 @@ pyinstaller
 requests
 openpyxl
 xlrd
+
+# Security fixes for transitive dependencies
+urllib3>=2.6.0  # CVE-2025-66418, CVE-2025-66471 - compression handling
+starlette>=0.49.1  # CVE-2024-47874 - Range header DoS


### PR DESCRIPTION
## Summary

Addresses high-severity security vulnerabilities by adding explicit version pins in `requirements.in`.

## Changes

### urllib3 >= 2.6.0
- **CVE-2025-66418**: Unbounded decompression of chained HTTP encoding algorithms
- **CVE-2025-66471**: Streaming API improperly handles highly compressed data

### starlette >= 0.49.1  
- **CVE-2024-47874**: O(n^2) DoS via Range header merging in FileResponse

## Note on ecdsa vulnerability

The `ecdsa` package alert (Minerva timing attack) is a transitive dependency of `python-jose`. However, we explicitly use the cryptography backend (`python-jose[cryptography]`) which should mitigate this issue.

## Remaining Alerts

After this PR, the remaining open alert is:
- **Playwright** (#149) - Separate PR for E2E package