### PR TITLE
fix(security): Update urllib3 and starlette to patched versions

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -190,8 +190,10 @@ sqlalchemy==2.0.42
     #   sqlalchemy-utils
 sqlalchemy-utils==0.41.2
     # via -r requirements.in
-starlette==0.47.2
-    # via fastapi
+starlette==0.49.1
+    # via
+    #   -r requirements.in
+    #   fastapi
 tenacity==9.1.2
     # via -r requirements.in
 typer==0.16.0
@@ -214,8 +216,10 @@ typing-inspection==0.4.1
     #   pydantic-settings
 tzdata==2025.2
     # via pandas
-urllib3==2.5.0
-    # via requests
+urllib3==2.6.0
+    # via
+    #   -r requirements.in
+    #   requests
 uvicorn[standard]==0.35.0
     # via -r requirements.in
 uvloop==0.21.0


### PR DESCRIPTION
## Summary

Updates requirements.txt with patched versions of vulnerable dependencies.

## Changes

| Package | Old Version | New Version | CVEs Fixed |
|---------|-------------|-------------|------------|
| urllib3 | 2.5.0 | 2.6.0 | CVE-2025-66418, CVE-2025-66471 |
| starlette | 0.47.2 | 0.49.1 | CVE-2024-47874 |

## Remaining Alerts

After this PR, 2 alerts for `ecdsa` will remain open. These are transitive dependencies from `python-jose`. However, we explicitly use the cryptography backend (`python-jose[cryptography]`) which means the vulnerable `ecdsa` library is not used for cryptographic operations.

We should consider either:
1. Dismissing these alerts with justification
2. Switching from `python-jose` to `PyJWT` (requires code changes)