### PR TITLE
fix(security): Update urllib3 to 2.6.0 for CVE fixes

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -214,8 +214,10 @@ typing-inspection==0.4.1
     #   pydantic-settings
 tzdata==2025.2
     # via pandas
-urllib3==2.5.0
-    # via requests
+urllib3==2.6.0
+    # via
+    #   -r requirements.in
+    #   requests
 uvicorn[standard]==0.35.0
     # via -r requirements.in
 uvloop==0.21.0


### PR DESCRIPTION
## Summary

Updates urllib3 to fix high-severity compression handling vulnerabilities.

## Changes

| Package | Old | New | CVEs Fixed |
|---------|-----|-----|------------|
| urllib3 | 2.5.0 | 2.6.0 | CVE-2025-66418, CVE-2025-66471 |

## Testing

 Tested locally - all analytics tests pass

## Remaining Alerts

| Package | Issue | Status |
|---------|-------|--------|
| starlette | CVE-2025-62727 | Requires 0.49.1, but FastAPI 0.118.0 requires <0.49.0. **No fix available yet.** |
| ecdsa (x2) | Minerva timing attack | Transitive dep from python-jose, mitigated by using cryptography backend |

The starlette alert cannot be fixed until FastAPI releases a version that supports starlette>=0.49.1.