### PR TITLE
fix(security): Update FastAPI to 0.121.3 and starlette to 0.49.1

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -55,7 +55,7 @@ email-validator==2.2.0
     # via -r requirements.in
 et-xmlfile==2.0.0
     # via openpyxl
-fastapi==0.116.1
+fastapi==0.121.3
     # via -r requirements.in
 frozendict==2.4.6
     # via yfinance
@@ -190,8 +190,10 @@ sqlalchemy==2.0.42
     #   sqlalchemy-utils
 sqlalchemy-utils==0.41.2
     # via -r requirements.in
-starlette==0.47.2
-    # via fastapi
+starlette==0.49.1
+    # via
+    #   -r requirements.in
+    #   fastapi
 tenacity==9.1.2
     # via -r requirements.in
 typer==0.16.0


### PR DESCRIPTION
## Summary

Updates FastAPI and starlette to fix CVE-2025-62727 (Range header DoS vulnerability).

## Changes

| Package | Old | New | CVEs Fixed |
|---------|-----|-----|------------|
| FastAPI | 0.116.1 | 0.121.3 | Enables starlette update |
| starlette | 0.47.2 | 0.49.1 | CVE-2025-62727 |

## Testing

 Tested locally - all 31 tests pass (analytics + auth)

## FastAPI 0.121.3 Release Notes
- Bumps Starlette to <0.51.0 (was <0.48.0)
- Makes Depends() and Security() hashable

## Remaining Alerts After This PR

| Package | Issue | Status |
|---------|-------|--------|
| ecdsa (x2) | Minerva timing attack | Transitive from python-jose, mitigated by cryptography backend |