### PR TITLE
fix: Reset idle state on login to prevent stale timeout modal

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -104,6 +104,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const login = (data: { access_token: string, deployment_mode: 'server' | 'desktop' }) => {
     setToken(data.access_token);
     setDeploymentMode(data.deployment_mode);
+    setIsIdle(false);  // Reset idle state on login
     localStorage.setItem('token', data.access_token);
     localStorage.setItem('deployment_mode', data.deployment_mode);
   };


### PR DESCRIPTION
After inactivity timeout and re-login, the timeout modal would appear because isIdle state wasn't reset.

**Fix**: Added `setIsIdle(false)` to the login function in AuthContext.