### PR TITLE
fix: Align Reset button on transaction history filter bar

### DIFF
--- a/frontend/src/components/Transactions/TransactionFilterBar.tsx
+++ b/frontend/src/components/Transactions/TransactionFilterBar.tsx
@@ -109,7 +109,10 @@ const TransactionFilterBar: React.FC = () => {
         <div className="form-group"><label htmlFor="end-date-filter" className="form-label">End Date</label><input type="date" id="end-date-filter" className="form-input" value={endDate} onChange={(e) => handleFilterChange('end_date', e.target.value)} /></div>
 
         {/* Action Buttons */}
-        <div className="flex space-x-2"><button type="button" onClick={handleReset} className="btn btn-secondary w-full">Reset</button></div>
+        <div className="form-group">
+          <label className="form-label invisible">Actions</label>
+          <button type="button" onClick={handleReset} className="btn btn-secondary w-full">Reset</button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
The Reset button was not aligned with other filter inputs. Added form-group wrapper with invisible label to match the layout.