### PR TITLE
feat(desktop): Add update notification (FR-Desktop-2)

### DIFF
--- a/frontend/electron/preload.cjs
+++ b/frontend/electron/preload.cjs
@@ -3,6 +3,10 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electronAPI', {
   getApiConfig: () => ipcRenderer.invoke('get-api-config'),
   openUserGuide: (sectionId) => ipcRenderer.invoke('open-user-guide', sectionId),
+  // Update notification API
+  checkForUpdates: () => ipcRenderer.invoke('check-for-updates'),
+  openReleasePage: (url) => ipcRenderer.invoke('open-release-page', url),
+  getAppVersion: () => ipcRenderer.invoke('get-app-version'),
 });
 
 // Splash screen specific API

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arthsaarthi-frontend",
-  "version": "1.0.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "arthsaarthi-frontend",
-      "version": "1.0.0",
+      "version": "0.9.0",
       "hasInstallScript": true,
       "dependencies": {
         "@heroicons/react": "^2.1.5",
@@ -22,6 +22,7 @@
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.60.0",
+        "react-icons": "^5.3.0",
         "react-router-dom": "^6.23.1",
         "react-select": "^5.10.2"
       },
@@ -12292,6 +12293,14 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arthsaarthi-frontend",
   "private": true,
-  "version": "1.0.0",
+  "version": "0.9.0",
   "type": "module",
   "homepage": "./",
   "author": {
@@ -76,6 +76,7 @@
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.60.0",
+    "react-icons": "^5.3.0",
     "react-router-dom": "^6.23.1",
     "react-select": "^5.10.2"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,9 +20,11 @@ import ErrorBoundary from './components/ErrorBoundary';
 import { ToastProvider } from './context/ToastContext';
 import { ThemeProvider } from './context/ThemeContext';
 import AssetLoadingBanner from './components/AssetLoadingBanner';
+import UpdateBanner from './components/UpdateBanner';
 
 const AppLayout = () => (
   <div className="flex flex-col h-screen bg-gray-50 dark:bg-gray-900">
+    <UpdateBanner />
     <AssetLoadingBanner />
     <div className="grid grid-cols-[auto_1fr] flex-1 overflow-hidden">
       <NavBar />

--- a/frontend/src/components/UpdateBanner.tsx
+++ b/frontend/src/components/UpdateBanner.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from 'react';
+import { FiDownload, FiX, FiInfo, FiExternalLink } from 'react-icons/fi';
+import api from '../services/api';
+import { useAuth } from '../context/AuthContext';
+
+interface UpdateInfo {
+    available: boolean;
+    version?: string;
+    url?: string;
+    name?: string;
+    error?: string;
+}
+
+const DISMISSED_VERSION_KEY = 'dismissed_update_version';
+
+export default function UpdateBanner() {
+    const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
+    const [dismissed, setDismissed] = useState(false);
+    const [isDesktopMode, setIsDesktopMode] = useState(false);
+    const { user } = useAuth();
+
+    const isAdmin = user?.is_admin === true;
+
+    useEffect(() => {
+        const checkUpdates = async () => {
+            try {
+                let result: UpdateInfo;
+
+                // Check if running in Electron (desktop mode)
+                if (window.electronAPI?.checkForUpdates) {
+                    setIsDesktopMode(true);
+                    result = await window.electronAPI.checkForUpdates();
+                } else {
+                    // Server mode - call backend API
+                    setIsDesktopMode(false);
+                    const response = await api.get('/api/v1/system/check-updates');
+                    result = response.data;
+                }
+
+                if (result.available && result.version) {
+                    // Check if this version was already dismissed
+                    const dismissedVersion = localStorage.getItem(DISMISSED_VERSION_KEY);
+                    if (dismissedVersion === result.version) {
+                        setDismissed(true);
+                        return;
+                    }
+                    setUpdateInfo(result);
+                }
+            } catch (err) {
+                console.error('Failed to check for updates:', err);
+            }
+        };
+
+        // Check after a short delay to not block initial load
+        const timer = setTimeout(checkUpdates, 3000);
+        return () => clearTimeout(timer);
+    }, []);
+
+    const handleViewRelease = () => {
+        if (updateInfo?.url) {
+            if (isDesktopMode && window.electronAPI?.openReleasePage) {
+                window.electronAPI.openReleasePage(updateInfo.url);
+            } else {
+                // Server mode - open in new tab
+                window.open(updateInfo.url, '_blank', 'noopener,noreferrer');
+            }
+        }
+    };
+
+    const handleDismiss = () => {
+        if (updateInfo?.version) {
+            localStorage.setItem(DISMISSED_VERSION_KEY, updateInfo.version);
+        }
+        setDismissed(true);
+    };
+
+    // Don't render if no update available or dismissed
+    if (!updateInfo?.available || dismissed) {
+        return null;
+    }
+
+    // Desktop mode - always show Download button
+    if (isDesktopMode) {
+        return (
+            <div className="update-banner">
+                <div className="update-banner-content">
+                    <FiDownload className="update-icon" />
+                    <span className="update-text">
+                        <strong>ArthSaarthi {updateInfo.version}</strong> is available!
+                    </span>
+                    <button
+                        onClick={handleViewRelease}
+                        className="update-download-btn"
+                        title="Open GitHub Releases"
+                    >
+                        Download
+                    </button>
+                </div>
+                <button
+                    onClick={handleDismiss}
+                    className="update-dismiss-btn"
+                    title="Dismiss this notification"
+                    aria-label="Dismiss update notification"
+                >
+                    <FiX />
+                </button>
+            </div>
+        );
+    }
+
+    // Server mode - Admin: show View Release Notes, Regular user: Ask admin
+    return (
+        <div className="update-banner">
+            <div className="update-banner-content">
+                <FiInfo className="update-icon" />
+                <span className="update-text">
+                    <strong>ArthSaarthi {updateInfo.version}</strong> is available!
+                    {!isAdmin && (
+                        <span className="update-admin-note"> Ask your administrator to update.</span>
+                    )}
+                </span>
+                {isAdmin && (
+                    <button
+                        onClick={handleViewRelease}
+                        className="update-download-btn"
+                        title="View release notes on GitHub"
+                    >
+                        <FiExternalLink className="inline mr-1" />
+                        View Release Notes
+                    </button>
+                )}
+            </div>
+            <button
+                onClick={handleDismiss}
+                className="update-dismiss-btn"
+                title="Dismiss this notification"
+                aria-label="Dismiss update notification"
+            >
+                <FiX />
+            </button>
+        </div>
+    );
+}

--- a/frontend/src/electron.d.ts
+++ b/frontend/src/electron.d.ts
@@ -5,6 +5,16 @@ declare global {
     electronAPI?: {
       getApiConfig: () => Promise<{ host: string; port: number }>;
       openUserGuide: (sectionId?: string) => Promise<void>;
+      // Update notification API
+      checkForUpdates: () => Promise<{
+        available: boolean;
+        version?: string;
+        url?: string;
+        name?: string;
+        error?: string;
+      }>;
+      openReleasePage: (url: string) => Promise<void>;
+      getAppVersion: () => Promise<string>;
     };
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -179,3 +179,32 @@ body {
 .dark .hover\:bg-gray-100:hover {
     background-color: #4b5563 !important;
 }
+
+/* Update Banner Styles */
+.update-banner {
+    @apply fixed top-0 left-0 right-0 z-50 bg-gradient-to-r from-blue-600 to-blue-500 text-white py-2 px-4 flex items-center justify-between shadow-md;
+}
+
+.update-banner-content {
+    @apply flex items-center gap-3;
+}
+
+.update-icon {
+    @apply text-lg;
+}
+
+.update-text {
+    @apply text-sm;
+}
+
+.update-download-btn {
+    @apply bg-white text-blue-600 font-semibold py-1 px-3 rounded text-sm hover:bg-blue-50 transition-colors;
+}
+
+.update-dismiss-btn {
+    @apply p-1 hover:bg-blue-700 rounded transition-colors;
+}
+
+.update-admin-note {
+    @apply text-blue-100 ml-1;
+}


### PR DESCRIPTION
## Summary

Implements FR-Desktop-2: Update notification for desktop and server modes.

## Features

### Desktop Mode (Electron)
- Checks GitHub Releases API on startup (3s delay)
- Shows dismissible banner with Download button
- Download button opens GitHub Releases page
- Dismissed versions saved to localStorage

### Server Mode (Docker)
- Backend endpoint GET /api/v1/system/check-updates
- Admin users: See View Release Notes button
- Regular users: See Ask your administrator to update

## Changes

- main.cjs: Added checkForUpdates(), isNewerVersion(), IPC handlers
- preload.cjs: Added update API to electronAPI
- system.py: Added /check-updates endpoint
- UpdateBanner.tsx: NEW - Dismissible banner with role-based messaging
- electron.d.ts: TypeScript types for update API
- index.css: Banner styles
- App.tsx: Integrated UpdateBanner
- package.json: Added react-icons, set version 0.9.0 for testing

Note: Version set to 0.9.0 for testing. Update to 1.0.0 before release.

Closes #153