### PR TITLE
feat(admin): add Symbol Alias management CRUD UI and API (#215)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The project was developed following a rigorous, AI-assisted Agile SDLC, with a s
 *   **Holdings Drill-Down:** Click on any holding to see a detailed modal with its constituent buy transactions, calculated using FIFO logic.
 *   **Automated Data Import:** A full-stack workflow for uploading, parsing, previewing, and committing transaction data from CSV/Excel files.
     *   Includes pre-built parsers for Zerodha, ICICI Direct, MFCentral CAS, CAMS Statement, Zerodha Coin MF, KFintech PDF, and a generic format.
-    *   Features an advanced UI for on-the-fly **asset alias mapping** for unrecognized ticker symbols.
+    *   Features an advanced UI for on-the-fly **asset alias mapping** for unrecognized ticker symbols, with admin management (view, edit, delete) of all aliases.
 *   **Tax Compliance & Reporting:**
     *   **Schedule FA (Foreign Assets):** Generate reports compliant with Calendar Year rules, including Peak Value analysis (daily balance check) and specific field exports.
     *   **Capital Gains:** Comprehensive reports for Short-Term (STCG) and Long-Term (LTCG) capital gains.

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -3,6 +3,7 @@ import logging
 from fastapi import APIRouter
 
 from app.api.v1.endpoints import (
+    admin_aliases,
     admin_assets,
     admin_interest_rates,
     assets,
@@ -61,6 +62,11 @@ api_router.include_router(
     admin_assets.router,
     prefix="/admin/assets",
     tags=["admin-assets"],
+)
+api_router.include_router(
+    admin_aliases.router,
+    prefix="/admin/aliases",
+    tags=["admin-aliases"],
 )
 api_router.include_router(fx.router, prefix="/fx-rate", tags=["fx-rate"])
 

--- a/backend/app/api/v1/endpoints/admin_aliases.py
+++ b/backend/app/api/v1/endpoints/admin_aliases.py
@@ -1,0 +1,103 @@
+"""
+Admin endpoints for symbol alias management.
+"""
+import logging
+import uuid
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app import crud, schemas
+from app.core.dependencies import get_current_admin_user
+from app.db.session import get_db
+from app.models.user import User as UserModel
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+@router.get("/", response_model=List[schemas.AssetAliasWithAsset])
+def list_aliases(
+    db: Session = Depends(get_db),
+    current_user: UserModel = Depends(get_current_admin_user),
+):
+    """List all symbol aliases with associated asset info."""
+    aliases = crud.asset_alias.get_all_with_assets(db)
+    result = []
+    for alias in aliases:
+        result.append(schemas.AssetAliasWithAsset(
+            id=alias.id,
+            alias_symbol=alias.alias_symbol,
+            source=alias.source,
+            asset_id=alias.asset_id,
+            asset_name=alias.asset.name if alias.asset else "",
+            asset_ticker=alias.asset.ticker_symbol if alias.asset else "",
+        ))
+    return result
+
+
+@router.post("/", response_model=schemas.AssetAlias, status_code=201)
+def create_alias(
+    alias_in: schemas.AssetAliasCreate,
+    db: Session = Depends(get_db),
+    current_user: UserModel = Depends(get_current_admin_user),
+):
+    """Create a new symbol alias."""
+    # Check for duplicate
+    existing = crud.asset_alias.get_by_alias(
+        db, alias_symbol=alias_in.alias_symbol, source=alias_in.source
+    )
+    if existing:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Alias '{alias_in.alias_symbol}' already exists"
+                f" for source '{alias_in.source}'."
+            ),
+        )
+    # Verify asset exists
+    asset = crud.asset.get(db, id=alias_in.asset_id)
+    if not asset:
+        raise HTTPException(status_code=404, detail="Target asset not found.")
+    alias = crud.asset_alias.create(db, obj_in=alias_in)
+    db.commit()
+    db.refresh(alias)
+    return alias
+
+
+@router.put("/{alias_id}", response_model=schemas.AssetAlias)
+def update_alias(
+    alias_id: uuid.UUID,
+    alias_in: schemas.AssetAliasUpdate,
+    db: Session = Depends(get_db),
+    current_user: UserModel = Depends(get_current_admin_user),
+):
+    """Update an existing symbol alias."""
+    db_alias = crud.asset_alias.get(db, id=alias_id)
+    if not db_alias:
+        raise HTTPException(status_code=404, detail="Alias not found.")
+    # If changing asset_id, verify it exists
+    if alias_in.asset_id is not None:
+        asset = crud.asset.get(db, id=alias_in.asset_id)
+        if not asset:
+            raise HTTPException(status_code=404, detail="Target asset not found.")
+    updated = crud.asset_alias.update(db, db_obj=db_alias, obj_in=alias_in)
+    db.commit()
+    db.refresh(updated)
+    return updated
+
+
+@router.delete("/{alias_id}")
+def delete_alias(
+    alias_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: UserModel = Depends(get_current_admin_user),
+):
+    """Delete a symbol alias."""
+    db_alias = crud.asset_alias.get(db, id=alias_id)
+    if not db_alias:
+        raise HTTPException(status_code=404, detail="Alias not found.")
+    crud.asset_alias.remove(db, id=alias_id)
+    db.commit()
+    return {"msg": "Alias deleted successfully."}

--- a/backend/app/crud/crud_asset_alias.py
+++ b/backend/app/crud/crud_asset_alias.py
@@ -1,13 +1,13 @@
-from typing import Optional
+from typing import List, Optional
 
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from app.crud.base import CRUDBase
 from app.models.asset_alias import AssetAlias
-from app.schemas.asset_alias import AssetAliasCreate
+from app.schemas.asset_alias import AssetAliasCreate, AssetAliasUpdate
 
 
-class CRUDAssetAlias(CRUDBase[AssetAlias, AssetAliasCreate, AssetAliasCreate]):
+class CRUDAssetAlias(CRUDBase[AssetAlias, AssetAliasCreate, AssetAliasUpdate]):
     def get_by_alias(
         self, db: Session, *, alias_symbol: str, source: str
     ) -> Optional[AssetAlias]:
@@ -17,6 +17,15 @@ class CRUDAssetAlias(CRUDBase[AssetAlias, AssetAliasCreate, AssetAliasCreate]):
                 self.model.alias_symbol == alias_symbol, self.model.source == source
             )
             .first()
+        )
+
+    def get_all_with_assets(self, db: Session) -> List[AssetAlias]:
+        """Fetch all aliases with eager-loaded asset relationship."""
+        return (
+            db.query(self.model)
+            .options(joinedload(self.model.asset))
+            .order_by(self.model.alias_symbol)
+            .all()
         )
 
 

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -14,7 +14,12 @@ from .asset import (
     AssetUpdate,
     PpfAccountCreate,
 )
-from .asset_alias import AssetAlias, AssetAliasCreate
+from .asset_alias import (
+    AssetAlias,
+    AssetAliasCreate,
+    AssetAliasUpdate,
+    AssetAliasWithAsset,
+)
 from .bond import (
     BondCreate,
     BondUpdate,
@@ -106,6 +111,8 @@ __all__ = [
     "FixedDepositDetails",
     "FixedDepositUpdate",
     "AssetAliasCreate",
+    "AssetAliasUpdate",
+    "AssetAliasWithAsset",
     "AssetAllocation",
     "AssetAllocationResponse",
     "AssetCreate",

--- a/backend/app/schemas/asset_alias.py
+++ b/backend/app/schemas/asset_alias.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -10,9 +11,19 @@ class AssetAliasBase(BaseModel):
 class AssetAliasCreate(AssetAliasBase):
     asset_id: uuid.UUID
 
+class AssetAliasUpdate(BaseModel):
+    alias_symbol: Optional[str] = None
+    source: Optional[str] = None
+    asset_id: Optional[uuid.UUID] = None
+
 class AssetAlias(AssetAliasBase):
     id: uuid.UUID
     asset_id: uuid.UUID
 
     class Config:
         from_attributes = True
+
+class AssetAliasWithAsset(AssetAlias):
+    """Alias response enriched with asset name and ticker for display."""
+    asset_name: str = ""
+    asset_ticker: str = ""

--- a/backend/app/tests/api/v1/test_admin_aliases.py
+++ b/backend/app/tests/api/v1/test_admin_aliases.py
@@ -1,0 +1,165 @@
+"""
+API tests for admin alias endpoints.
+Tests CRUD operations and non-admin access denial.
+"""
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.tests.utils.asset import create_test_asset
+from app.tests.utils.user import create_random_user, get_access_token
+
+pytestmark = pytest.mark.usefixtures("pre_unlocked_key_manager")
+
+API_PREFIX = f"{settings.API_V1_STR}/admin/aliases"
+
+
+def _admin_headers(client: TestClient, db: Session) -> dict:
+    """Helper to create an admin user and return auth headers."""
+    admin_user, admin_password = create_random_user(db, is_admin=True)
+    token = get_access_token(client, admin_user.email, admin_password)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_create_alias(client: TestClient, db: Session) -> None:
+    """Test creating a new symbol alias via the API."""
+    headers = _admin_headers(client, db)
+    asset = create_test_asset(db, ticker_symbol="TESTALIAS1", name="Test Alias Asset")
+    db.commit()
+
+    data = {
+        "alias_symbol": "MYALIAS",
+        "source": "Zerodha Tradebook",
+        "asset_id": str(asset.id),
+    }
+    response = client.post(f"{API_PREFIX}/", headers=headers, json=data)
+    assert response.status_code == 201
+    content = response.json()
+    assert content["alias_symbol"] == "MYALIAS"
+    assert content["source"] == "Zerodha Tradebook"
+    assert content["asset_id"] == str(asset.id)
+    assert "id" in content
+
+
+def test_list_aliases(client: TestClient, db: Session) -> None:
+    """Test listing all aliases returns created alias with asset info."""
+    headers = _admin_headers(client, db)
+    asset = create_test_asset(db, ticker_symbol="LISTTEST", name="List Test Asset")
+    db.commit()
+
+    # Create an alias first
+    client.post(
+        f"{API_PREFIX}/",
+        headers=headers,
+        json={
+            "alias_symbol": "LISTALIAS",
+            "source": "Test Source",
+            "asset_id": str(asset.id),
+        },
+    )
+
+    response = client.get(f"{API_PREFIX}/", headers=headers)
+    assert response.status_code == 200
+    content = response.json()
+    assert isinstance(content, list)
+    assert len(content) > 0
+    # Find our created alias
+    our_alias = [a for a in content if a["alias_symbol"] == "LISTALIAS"]
+    assert len(our_alias) == 1
+    assert our_alias[0]["asset_name"] == "List Test Asset"
+    assert our_alias[0]["asset_ticker"] == "LISTTEST"
+
+
+def test_update_alias(client: TestClient, db: Session) -> None:
+    """Test updating an alias changes its fields."""
+    headers = _admin_headers(client, db)
+    asset1 = create_test_asset(db, ticker_symbol="UPDASSET1", name="First Asset")
+    asset2 = create_test_asset(db, ticker_symbol="UPDASSET2", name="Second Asset")
+    db.commit()
+
+    # Create an alias
+    response = client.post(
+        f"{API_PREFIX}/",
+        headers=headers,
+        json={
+            "alias_symbol": "OLDALIAS",
+            "source": "Old Source",
+            "asset_id": str(asset1.id),
+        },
+    )
+    alias_id = response.json()["id"]
+
+    # Update it
+    update_data = {
+        "alias_symbol": "NEWALIAS",
+        "source": "New Source",
+        "asset_id": str(asset2.id),
+    }
+    response = client.put(
+        f"{API_PREFIX}/{alias_id}", headers=headers, json=update_data
+    )
+    assert response.status_code == 200
+    content = response.json()
+    assert content["alias_symbol"] == "NEWALIAS"
+    assert content["source"] == "New Source"
+    assert content["asset_id"] == str(asset2.id)
+
+
+def test_delete_alias(client: TestClient, db: Session) -> None:
+    """Test deleting an alias removes it."""
+    headers = _admin_headers(client, db)
+    asset = create_test_asset(db, ticker_symbol="DELTEST", name="Delete Test")
+    db.commit()
+
+    # Create
+    response = client.post(
+        f"{API_PREFIX}/",
+        headers=headers,
+        json={
+            "alias_symbol": "DELALIAS",
+            "source": "Test",
+            "asset_id": str(asset.id),
+        },
+    )
+    alias_id = response.json()["id"]
+
+    # Delete
+    response = client.delete(f"{API_PREFIX}/{alias_id}", headers=headers)
+    assert response.status_code == 200
+    assert response.json()["msg"] == "Alias deleted successfully."
+
+    # Verify it's gone from the list
+    response = client.get(f"{API_PREFIX}/", headers=headers)
+    ids = [a["id"] for a in response.json()]
+    assert alias_id not in ids
+
+
+def test_create_duplicate_alias_rejected(client: TestClient, db: Session) -> None:
+    """Test that creating a duplicate alias_symbol+source is rejected."""
+    headers = _admin_headers(client, db)
+    asset = create_test_asset(db, ticker_symbol="DUPTEST", name="Dup Test")
+    db.commit()
+
+    data = {
+        "alias_symbol": "DUPALIAS",
+        "source": "Same Source",
+        "asset_id": str(asset.id),
+    }
+    response = client.post(f"{API_PREFIX}/", headers=headers, json=data)
+    assert response.status_code == 201
+
+    # Try creating the same one again
+    response = client.post(f"{API_PREFIX}/", headers=headers, json=data)
+    assert response.status_code == 400
+    assert "already exists" in response.json()["detail"]
+
+
+def test_non_admin_cannot_access(client: TestClient, db: Session) -> None:
+    """Test that non-admin users get 403 on alias endpoints."""
+    user, password = create_random_user(db, is_admin=False)
+    token = get_access_token(client, user.email, password)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    response = client.get(f"{API_PREFIX}/", headers=headers)
+    assert response.status_code == 403

--- a/docs/product_backlog.md
+++ b/docs/product_backlog.md
@@ -174,6 +174,7 @@ The goal of this release was to build a robust and user-friendly system for impo
 -   **Manual Asset Seeding (FR9):** Allow admins to trigger asset master updates from the UI without restarting the server.
 -   **Capital Gains Report (FR10):** Generate Short-Term (STCG), Long-Term (LTCG), and Schedule 112A reports. **✅ Complete**
 -   **Foreign Assets Reporting (Schedule FA):** Peak Value tracking and Calendar Year reporting. **✅ Complete**
+-   **Symbol Alias Management (#215):** Admin UI to view, create, edit, and delete symbol aliases used during data import. **✅ Complete**
 -   **Automated Data Import - Phase 3 (FR7):** Implement a parser for Consolidated Account Statements (MF CAS).
 -   **Forgotten Password Flow (FR1.6):** Implement a secure password reset mechanism.
 

--- a/docs/project_handoff_summary.md
+++ b/docs/project_handoff_summary.md
@@ -42,7 +42,7 @@
 -   **Dashboard:** High-level summary, historical chart, asset allocation, and top movers.
 -   **Consolidated Holdings View:** Grouped by asset class with sorting and drill-down for transaction history.
 -   **Advanced Analytics:** Portfolio and Asset-level XIRR calculation.
--   **Automated Data Import:** Support for Zerodha, ICICI Direct, and generic CSV files with on-the-fly asset alias mapping.
+-   **Automated Data Import:** Support for Zerodha, ICICI Direct, and generic CSV files with on-the-fly **asset alias mapping** for unrecognized ticker symbols. Aliases are manageable (CRUD) from the Admin section.
 -   **Watchlists:** Create and manage custom watchlists.
 -   **Goal Planning:** Define financial goals and link assets to track progress.
 -   **Mutual Fund Dividends:** Track both cash and reinvested dividends for mutual funds.

--- a/docs/workflow_history.md
+++ b/docs/workflow_history.md
@@ -1,3 +1,56 @@
+## 2026-02-15: Add Admin UI for Symbol Alias Management (#215)
+
+**Task:** Implement full CRUD (create, read, update, delete) for symbol aliases, accessible from the Admin section. Previously, aliases could only be created during import but never viewed, edited, or deleted.
+
+**AI Assistant:** Antigravity
+**Role:** Full-Stack Developer
+
+### Summary
+
+Delivered a complete admin feature for managing symbol aliases:
+
+1.  **Backend API:**
+    -   Created new admin endpoint `admin_aliases.py` with 4 routes: `GET /`, `POST /`, `PUT /{id}`, `DELETE /{id}`.
+    -   Updated `CRUDAssetAlias` with `get_all_with_assets` (eager-loaded asset join).
+    -   Added `AssetAliasUpdate` and `AssetAliasWithAsset` schemas for partial updates and enriched responses.
+    -   Registered router at `/admin/aliases` in `api.py`.
+
+2.  **Frontend:**
+    -   Created `AdminAliasesPage.tsx` with table view, create/edit modal with live asset search, and delete confirmation.
+    -   Added alias CRUD functions to `adminApi.ts`.
+    -   Added route and nav link in `App.tsx` and `NavBar.tsx`.
+
+3.  **Testing:**
+    -   Added 6 API endpoint tests in `test_admin_aliases.py`: create, list (with asset info), update, delete, duplicate rejection, and non-admin access denial. All passed.
+
+### File Changes
+
+**Backend:**
+*   **New:** `backend/app/api/v1/endpoints/admin_aliases.py`
+*   **New:** `backend/app/tests/api/v1/test_admin_aliases.py`
+*   **Modified:** `backend/app/api/v1/api.py` - Registered admin_aliases router
+*   **Modified:** `backend/app/crud/crud_asset_alias.py` - Added `get_all_with_assets`, updated generic types
+*   **Modified:** `backend/app/schemas/asset_alias.py` - Added `AssetAliasUpdate`, `AssetAliasWithAsset`
+*   **Modified:** `backend/app/schemas/__init__.py` - Exported new schemas
+
+**Frontend:**
+*   **New:** `frontend/src/pages/Admin/AdminAliasesPage.tsx`
+*   **Modified:** `frontend/src/services/adminApi.ts` - Added alias CRUD functions
+*   **Modified:** `frontend/src/App.tsx` - Added `/admin/aliases` route
+*   **Modified:** `frontend/src/components/NavBar.tsx` - Added Symbol Aliases nav link
+
+### Verification
+
+*   **Backend Tests:** `test_admin_aliases.py` — 6 passed.
+*   **Frontend Build:** `tsc --noEmit` — Clean (no errors).
+*   **Backend Health:** Container healthy after import fix.
+
+### Outcome
+
+**Success.** Admins can now view, create, edit, and delete symbol aliases from the new "Symbol Aliases" page under the Admin section. Closes #215.
+
+---
+
 ## 2026-01-28: Implement Foreign Assets (Schedule FA) & Capital Gains Reporting
 
 **Task:** Implement detailed Foreign Assets reporting (Schedule FA) compliant with Calendar Year rules, and Capital Gains reporting (Schedule 112A) for Grandfathered Equity.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import AdminRoute from './components/auth/AdminRoute';
 import UserManagementPage from './pages/Admin/UserManagementPage';
 import SystemMaintenancePage from './pages/Admin/SystemMaintenancePage';
 import AdminFMVPage from './pages/Admin/AdminFMVPage';
+import AdminAliasesPage from './pages/Admin/AdminAliasesPage';
 import PortfolioPage from './pages/Portfolio/PortfolioPage';
 import PortfolioDetailPage from './pages/Portfolio/PortfolioDetailPage';
 import DataImportPage from './pages/Import/DataImportPage';
@@ -61,6 +62,7 @@ function AppRoutes() {
             <Route path="/admin/interest-rates" element={<InterestRateManagementPage />} />
             <Route path="/admin/maintenance" element={<SystemMaintenancePage />} />
             <Route path="/admin/fmv" element={<AdminFMVPage />} />
+            <Route path="/admin/aliases" element={<AdminAliasesPage />} />
           </Route>
         </Route>
       </Route>

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -146,6 +146,10 @@ const NavBar: React.FC = () => {
                             <ScaleIcon className="h-5 w-5" />
                             <span>FMV Management</span>
                         </NavLink>
+                        <NavLink to="/admin/aliases" className={({ isActive }) => linkClass(isActive)}>
+                            <ListBulletIcon className="h-5 w-5" />
+                            <span>Symbol Aliases</span>
+                        </NavLink>
                     </>
                 )}
             </nav>

--- a/frontend/src/pages/Admin/AdminAliasesPage.tsx
+++ b/frontend/src/pages/Admin/AdminAliasesPage.tsx
@@ -1,0 +1,299 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+    getAliases,
+    createAlias,
+    updateAlias,
+    deleteAlias,
+    AssetAliasWithAsset,
+    AssetAliasCreate,
+    AssetAliasUpdate,
+} from '../../services/adminApi';
+import apiClient from '../../services/api';
+import { AxiosError } from 'axios';
+import { DeleteConfirmationModal } from '../../components/common/DeleteConfirmationModal';
+import { useToast } from '../../context/ToastContext';
+import { PencilIcon, TrashIcon, PlusIcon } from '@heroicons/react/24/outline';
+
+interface LocalAsset {
+    id: string;
+    ticker_symbol: string;
+    name: string;
+    asset_type: string;
+}
+
+const AdminAliasesPage: React.FC = () => {
+    const queryClient = useQueryClient();
+    const { addToast } = useToast();
+
+    const { data: aliases = [], isLoading, isError } = useQuery({
+        queryKey: ['adminAliases'],
+        queryFn: getAliases,
+    });
+
+    // --- Form Modal State ---
+    const [isFormOpen, setFormOpen] = useState(false);
+    const [editingAlias, setEditingAlias] = useState<AssetAliasWithAsset | null>(null);
+    const [formData, setFormData] = useState({ alias_symbol: '', source: '', asset_id: '' });
+
+    // --- Asset Search ---
+    const [assetQuery, setAssetQuery] = useState('');
+    const [assetResults, setAssetResults] = useState<LocalAsset[]>([]);
+    const [selectedAsset, setSelectedAsset] = useState<LocalAsset | null>(null);
+    const [showDropdown, setShowDropdown] = useState(false);
+
+    // --- Delete Modal State ---
+    const [isDeleteOpen, setDeleteOpen] = useState(false);
+    const [deletingAlias, setDeletingAlias] = useState<AssetAliasWithAsset | null>(null);
+
+    // Asset search with debounce
+    const searchAssets = useCallback(async (query: string) => {
+        if (query.length < 2) {
+            setAssetResults([]);
+            return;
+        }
+        try {
+            const response = await apiClient.get<LocalAsset[]>('/api/v1/admin/assets/search-local', {
+                params: { query, limit: 10 },
+            });
+            setAssetResults(response.data);
+            setShowDropdown(true);
+        } catch {
+            setAssetResults([]);
+        }
+    }, []);
+
+    useEffect(() => {
+        const timer = setTimeout(() => searchAssets(assetQuery), 300);
+        return () => clearTimeout(timer);
+    }, [assetQuery, searchAssets]);
+
+    // Mutations
+    const createMutation = useMutation({
+        mutationFn: (data: AssetAliasCreate) => createAlias(data),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['adminAliases'] });
+            addToast('Alias created successfully.', 'success');
+            closeForm();
+        },
+        onError: (err: AxiosError<{ detail?: string }>) => {
+            addToast(err.response?.data?.detail || 'Failed to create alias.', 'error');
+        },
+    });
+
+    const updateMutation = useMutation({
+        mutationFn: ({ id, data }: { id: string; data: AssetAliasUpdate }) => updateAlias(id, data),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['adminAliases'] });
+            addToast('Alias updated successfully.', 'success');
+            closeForm();
+        },
+        onError: (err: AxiosError<{ detail?: string }>) => {
+            addToast(err.response?.data?.detail || 'Failed to update alias.', 'error');
+        },
+    });
+
+    const deleteMutation = useMutation({
+        mutationFn: (id: string) => deleteAlias(id),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['adminAliases'] });
+            addToast('Alias deleted.', 'success');
+            setDeleteOpen(false);
+            setDeletingAlias(null);
+        },
+        onError: () => {
+            addToast('Failed to delete alias.', 'error');
+        },
+    });
+
+    // Handlers
+    const openCreateForm = () => {
+        setEditingAlias(null);
+        setFormData({ alias_symbol: '', source: '', asset_id: '' });
+        setSelectedAsset(null);
+        setAssetQuery('');
+        setFormOpen(true);
+    };
+
+    const openEditForm = (alias: AssetAliasWithAsset) => {
+        setEditingAlias(alias);
+        setFormData({
+            alias_symbol: alias.alias_symbol,
+            source: alias.source,
+            asset_id: alias.asset_id,
+        });
+        setSelectedAsset({ id: alias.asset_id, ticker_symbol: alias.asset_ticker, name: alias.asset_name, asset_type: '' });
+        setAssetQuery(`${alias.asset_ticker} — ${alias.asset_name}`);
+        setFormOpen(true);
+    };
+
+    const closeForm = () => {
+        setFormOpen(false);
+        setEditingAlias(null);
+        setAssetResults([]);
+        setShowDropdown(false);
+    };
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!formData.alias_symbol || !formData.source || !formData.asset_id) {
+            addToast('Please fill all fields and select an asset.', 'error');
+            return;
+        }
+        if (editingAlias) {
+            updateMutation.mutate({ id: editingAlias.id, data: formData });
+        } else {
+            createMutation.mutate(formData);
+        }
+    };
+
+    const selectAsset = (asset: LocalAsset) => {
+        setSelectedAsset(asset);
+        setFormData({ ...formData, asset_id: asset.id });
+        setAssetQuery(`${asset.ticker_symbol} — ${asset.name}`);
+        setShowDropdown(false);
+    };
+
+    const isSaving = createMutation.isPending || updateMutation.isPending;
+
+    return (
+        <div className="container mx-auto">
+            <div className="flex justify-between items-center mb-6">
+                <h1 className="text-3xl font-bold">Symbol Aliases</h1>
+                <button onClick={openCreateForm} className="btn btn-primary flex items-center gap-2">
+                    <PlusIcon className="h-5 w-5" />
+                    Add Alias
+                </button>
+            </div>
+
+            {isLoading && <p>Loading aliases...</p>}
+            {isError && <p className="text-red-500">Error fetching aliases.</p>}
+            {!isLoading && !isError && (
+                <div className="card overflow-x-auto">
+                    {aliases.length === 0 ? (
+                        <p className="text-gray-500 p-4 text-center">No symbol aliases found. Create one to map unrecognized tickers to known assets.</p>
+                    ) : (
+                        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                            <thead className="bg-gray-50 dark:bg-gray-700">
+                                <tr>
+                                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Alias Symbol</th>
+                                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Source</th>
+                                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Maps To (Ticker)</th>
+                                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Asset Name</th>
+                                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                                {aliases.map((alias) => (
+                                    <tr key={alias.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                                        <td className="px-4 py-3 whitespace-nowrap font-mono text-sm">{alias.alias_symbol}</td>
+                                        <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">{alias.source}</td>
+                                        <td className="px-4 py-3 whitespace-nowrap font-mono text-sm text-blue-600 dark:text-blue-400">{alias.asset_ticker}</td>
+                                        <td className="px-4 py-3 text-sm">{alias.asset_name}</td>
+                                        <td className="px-4 py-3 whitespace-nowrap text-right">
+                                            <button onClick={() => openEditForm(alias)} className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 mr-3" title="Edit">
+                                                <PencilIcon className="h-4 w-4 inline" />
+                                            </button>
+                                            <button onClick={() => { setDeletingAlias(alias); setDeleteOpen(true); }} className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300" title="Delete">
+                                                <TrashIcon className="h-4 w-4 inline" />
+                                            </button>
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    )}
+                </div>
+            )}
+
+            {/* Form Modal */}
+            {isFormOpen && (
+                <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={closeForm}>
+                    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-md mx-4 p-6" onClick={(e) => e.stopPropagation()}>
+                        <h2 className="text-xl font-bold mb-4">{editingAlias ? 'Edit Alias' : 'Create Alias'}</h2>
+                        <form onSubmit={handleSubmit} className="space-y-4">
+                            <div>
+                                <label className="block text-sm font-medium mb-1">Alias Symbol</label>
+                                <input
+                                    type="text"
+                                    value={formData.alias_symbol}
+                                    onChange={(e) => setFormData({ ...formData, alias_symbol: e.target.value })}
+                                    className="input w-full"
+                                    placeholder="e.g. HDFCAMC-EQ"
+                                    required
+                                />
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium mb-1">Source</label>
+                                <input
+                                    type="text"
+                                    value={formData.source}
+                                    onChange={(e) => setFormData({ ...formData, source: e.target.value })}
+                                    className="input w-full"
+                                    placeholder="e.g. Zerodha Tradebook, ICICI Direct"
+                                    required
+                                />
+                            </div>
+                            <div className="relative">
+                                <label className="block text-sm font-medium mb-1">Target Asset</label>
+                                <input
+                                    type="text"
+                                    value={assetQuery}
+                                    onChange={(e) => {
+                                        setAssetQuery(e.target.value);
+                                        setSelectedAsset(null);
+                                        setFormData({ ...formData, asset_id: '' });
+                                    }}
+                                    onFocus={() => assetResults.length > 0 && setShowDropdown(true)}
+                                    className="input w-full"
+                                    placeholder="Search by ticker or name..."
+                                    required
+                                />
+                                {showDropdown && assetResults.length > 0 && (
+                                    <ul className="absolute z-10 w-full mt-1 bg-white dark:bg-gray-700 border dark:border-gray-600 rounded-md shadow-lg max-h-48 overflow-auto">
+                                        {assetResults.map((asset) => (
+                                            <li
+                                                key={asset.id}
+                                                className="px-3 py-2 cursor-pointer hover:bg-blue-100 dark:hover:bg-gray-600 text-sm"
+                                                onClick={() => selectAsset(asset)}
+                                            >
+                                                <span className="font-mono font-semibold">{asset.ticker_symbol}</span>
+                                                <span className="text-gray-500 dark:text-gray-400 ml-2">— {asset.name}</span>
+                                                <span className="text-xs text-gray-400 dark:text-gray-500 ml-2">({asset.asset_type})</span>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                )}
+                                {selectedAsset && (
+                                    <p className="text-xs text-green-600 dark:text-green-400 mt-1">
+                                        ✓ Selected: {selectedAsset.ticker_symbol}
+                                    </p>
+                                )}
+                            </div>
+                            <div className="flex justify-end gap-3 pt-2">
+                                <button type="button" onClick={closeForm} className="btn btn-secondary">Cancel</button>
+                                <button type="submit" className="btn btn-primary" disabled={isSaving || !formData.asset_id}>
+                                    {isSaving ? 'Saving...' : editingAlias ? 'Update' : 'Create'}
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            )}
+
+            {/* Delete Confirmation */}
+            {deletingAlias && (
+                <DeleteConfirmationModal
+                    isOpen={isDeleteOpen}
+                    onClose={() => { setDeleteOpen(false); setDeletingAlias(null); }}
+                    onConfirm={() => deleteMutation.mutate(deletingAlias.id)}
+                    title="Delete Alias"
+                    message={`Are you sure you want to delete the alias "${deletingAlias.alias_symbol}" (source: ${deletingAlias.source})?`}
+                    isDeleting={deleteMutation.isPending}
+                />
+            )}
+        </div>
+    );
+};
+
+export default AdminAliasesPage;

--- a/frontend/src/services/adminApi.ts
+++ b/frontend/src/services/adminApi.ts
@@ -68,3 +68,48 @@ export const syncAssets = async (): Promise<AssetSyncResponse> => {
   });
   return response.data;
 };
+
+// --- Symbol Alias Management (Admin) ---
+export interface AssetAliasWithAsset {
+  id: string;
+  alias_symbol: string;
+  source: string;
+  asset_id: string;
+  asset_name: string;
+  asset_ticker: string;
+}
+
+export interface AssetAliasCreate {
+  alias_symbol: string;
+  source: string;
+  asset_id: string;
+}
+
+export interface AssetAliasUpdate {
+  alias_symbol?: string;
+  source?: string;
+  asset_id?: string;
+}
+
+export const getAliases = async (): Promise<AssetAliasWithAsset[]> => {
+  const response = await apiClient.get('/api/v1/admin/aliases/');
+  return response.data;
+};
+
+export const createAlias = async (data: AssetAliasCreate): Promise<AssetAliasWithAsset> => {
+  const response = await apiClient.post('/api/v1/admin/aliases/', data);
+  return response.data;
+};
+
+export const updateAlias = async (
+  aliasId: string,
+  data: AssetAliasUpdate
+): Promise<AssetAliasWithAsset> => {
+  const response = await apiClient.put(`/api/v1/admin/aliases/${aliasId}`, data);
+  return response.data;
+};
+
+export const deleteAlias = async (aliasId: string): Promise<{ msg: string }> => {
+  const response = await apiClient.delete(`/api/v1/admin/aliases/${aliasId}`);
+  return response.data;
+};


### PR DESCRIPTION
## Summary

Implements full admin CRUD for symbol aliases. Previously, aliases could only be created on-the-fly during import but never viewed, edited, or deleted.

### Changes

**Backend:**
- New `admin_aliases.py` endpoint with list/create/update/delete routes
- New `AssetAliasUpdate` and `AssetAliasWithAsset` schemas
- Updated `CRUDAssetAlias` with `get_all_with_assets` (eager join)
- Registered router at `/admin/aliases`

**Frontend:**
- New `AdminAliasesPage` with table, create/edit modal (live asset search), and delete confirmation
- Added alias CRUD API functions to `adminApi.ts`
- Added route and nav link

**Testing:**
- 6 API endpoint tests: create, list, update, delete, duplicate rejection, non-admin access denial

**Docs:**
- Updated `workflow_history.md`, `product_backlog.md`, `project_handoff_summary.md`, `README.md`

### Verification
- [x] Backend tests: 6/6 passed
- [x] Frontend build: tsc --noEmit clean
- [x] Backend health check: healthy

Closes #215