### PR TITLE
feat(admin): Symbol Alias Search & ICICI Seeding Fixes (#216)

### DIFF
--- a/backend/app/tests/api/v1/test_admin_assets.py
+++ b/backend/app/tests/api/v1/test_admin_assets.py
@@ -1,0 +1,69 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.tests.utils.asset import create_test_asset
+from app.tests.utils.user import create_random_user, get_access_token
+
+pytestmark = pytest.mark.usefixtures("pre_unlocked_key_manager")
+
+API_PREFIX = f"{settings.API_V1_STR}/admin/assets"
+
+
+def _admin_headers(client: TestClient, db: Session) -> dict:
+    """Helper to create an admin user and return auth headers."""
+    admin_user, admin_password = create_random_user(db, is_admin=True)
+    token = get_access_token(client, admin_user.email, admin_password)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_search_local_assets_general(client: TestClient, db: Session) -> None:
+    """Test general asset search endpoint."""
+    headers = _admin_headers(client, db)
+
+    # Create test assets
+    # Create test assets
+    create_test_asset(db, ticker_symbol="SRCHTEST1", name="Search Asset One")
+    create_test_asset(db, ticker_symbol="SRCHTEST2", name="Search Asset Two")
+    db.commit()
+
+    # Search by ticker
+    response = client.get(
+        f"{API_PREFIX}/search-local",
+        headers=headers,
+        params={"query": "SRCHTEST1"}
+    )
+    assert response.status_code == 200
+    content = response.json()
+    assert len(content) >= 1
+    assert content[0]["ticker_symbol"] == "SRCHTEST1"
+
+    # Search by name
+    response = client.get(
+        f"{API_PREFIX}/search-local",
+        headers=headers,
+        params={"query": "Asset Two"}
+    )
+    assert response.status_code == 200
+    content = response.json()
+    found = False
+    for asset in content:
+        if asset["ticker_symbol"] == "SRCHTEST2":
+            found = True
+            break
+    assert found
+
+    # Search with no query (should return list)
+    response = client.get(
+        f"{API_PREFIX}/search-local",
+        headers=headers
+    )
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+
+def test_search_local_assets_requires_auth(client: TestClient) -> None:
+    """Test that auth is required."""
+    response = client.get(f"{API_PREFIX}/search-local")
+    assert response.status_code == 401

--- a/backend/app/tests/services/test_icici_alias_seeding.py
+++ b/backend/app/tests/services/test_icici_alias_seeding.py
@@ -1,0 +1,137 @@
+"""Tests for ICICI ShortName alias creation during asset seeding (#216)."""
+import pandas as pd
+import pytest
+from sqlalchemy.orm import Session
+
+from app import crud
+from app.services.asset_seeder import AssetSeeder
+
+
+@pytest.fixture()
+def seeder(db: Session):
+    """Create a fresh AssetSeeder instance."""
+    return AssetSeeder(db=db, debug=True)
+
+
+# ------------------------------------------------------------------ #
+#  _process_fallback_row  →  alias creation
+# ------------------------------------------------------------------ #
+
+def test_alias_created_when_shortname_differs(
+    seeder: AssetSeeder,
+    db: Session,
+):
+    """ShortName ≠ ExchangeCode → alias should be created."""
+    row = pd.Series({
+        "ExchangeCode": "HDFCAMC",
+        "CompanyName": "HDFC Asset Mgmt",
+        "ISINCode": "INE127TEST01",
+        "Series": "EQ",
+        "ShortName": "HDFCAMC-EQ",
+    })
+    seeder._process_fallback_row(row)
+    seeder.flush_pending()
+    db.commit()
+
+    # Asset should exist
+    asset = crud.asset.get_by_ticker(db, ticker_symbol="HDFCAMC")
+    assert asset is not None
+
+    # Alias should exist
+    alias = crud.asset_alias.get_by_alias(
+        db,
+        alias_symbol="HDFCAMC-EQ",
+        source="ICICI Direct Tradebook",
+    )
+    assert alias is not None
+    assert alias.asset_id == asset.id
+    assert seeder.alias_count == 1
+
+
+def test_no_alias_when_shortname_matches_ticker(
+    seeder: AssetSeeder,
+    db: Session,
+):
+    """ShortName == ticker (case-insensitive) → no alias."""
+    row = pd.Series({
+        "ExchangeCode": "RELIANCE",
+        "CompanyName": "Reliance Industries",
+        "ISINCode": "INE002TEST01",
+        "Series": "EQ",
+        "ShortName": "RELIANCE",
+    })
+    seeder._process_fallback_row(row)
+    seeder.flush_pending()
+    db.commit()
+
+    assert seeder.alias_count == 0
+
+
+def test_no_alias_when_shortname_missing(
+    seeder: AssetSeeder,
+    db: Session,
+):
+    """Missing ShortName column → no alias, no error."""
+    row = pd.Series({
+        "ExchangeCode": "TCS",
+        "CompanyName": "Tata Consultancy",
+        "ISINCode": "INE003TEST01",
+        "Series": "EQ",
+        # ShortName intentionally absent
+    })
+    seeder._process_fallback_row(row)
+    seeder.flush_pending()
+    db.commit()
+
+    assert seeder.alias_count == 0
+
+
+def test_no_alias_when_shortname_nan(
+    seeder: AssetSeeder,
+    db: Session,
+):
+    """ShortName is NaN → no alias."""
+    row = pd.Series({
+        "ExchangeCode": "INFY",
+        "CompanyName": "Infosys Ltd",
+        "ISINCode": "INE004TEST01",
+        "Series": "EQ",
+        "ShortName": float("nan"),
+    })
+    seeder._process_fallback_row(row)
+    seeder.flush_pending()
+    db.commit()
+
+    assert seeder.alias_count == 0
+
+
+def test_duplicate_alias_not_created_on_reseed(
+    seeder: AssetSeeder,
+    db: Session,
+):
+    """Re-seeding the same row should not create a duplicate alias."""
+    row = pd.Series({
+        "ExchangeCode": "SBIN",
+        "CompanyName": "State Bank of India",
+        "ISINCode": "INE005TEST01",
+        "Series": "EQ",
+        "ShortName": "SBI",
+    })
+    seeder._process_fallback_row(row)
+    seeder.flush_pending()
+    db.commit()
+    assert seeder.alias_count == 1
+
+    # Create a second seeder (simulates re-seed)
+    seeder2 = AssetSeeder(db=db, debug=True)
+    # Row won't create asset (ticker exists), so alias
+    # path won't be reached via _process_fallback_row.
+    # Instead, verify alias dedup via _create_alias directly.
+    asset = crud.asset.get_by_ticker(db, ticker_symbol="SBIN")
+    result = seeder2._create_alias(
+        alias_symbol="SBI",
+        source="ICICI Direct Tradebook",
+        asset_id=asset.id,
+    )
+    assert result is False  # Already exists
+    assert seeder2.alias_count == 0

--- a/backend/verify_scenario.py
+++ b/backend/verify_scenario.py
@@ -1,0 +1,32 @@
+from datetime import date
+
+
+# Mocking the service method for isolation
+def check_scenario():
+    buy_date = date(2023, 3, 1)
+    sell_date = date(2026, 1, 1)
+    days = (sell_date - buy_date).days
+
+    # Logic extracted from capital_gains_service.py
+    DATE_2023_04_01 = date(2023, 4, 1)
+    DATE_2024_07_23 = date(2024, 7, 23)
+
+    is_ltcg = False
+
+    # Category = DEBT
+    # 1. Invested ON/AFTER 1 Apr 2023
+    if buy_date >= DATE_2023_04_01:
+        is_ltcg = False
+    else:
+        # 2. Invested BEFORE 1 Apr 2023
+        if sell_date >= DATE_2024_07_23:
+            is_ltcg = days > 730
+        else:
+            is_ltcg = days > 1095
+
+    print(f"Buy: {buy_date}, Sell: {sell_date}")
+    print(f"Days: {days}")
+    print(f"Result: {'LTCG' if is_ltcg else 'STCG'}")
+
+if __name__ == "__main__":
+    check_scenario()

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,7 +7,7 @@ services:
 
   frontend:
     ports:
-      - "3000:3000"
+      - "30100:3000"
     volumes:
       - ./frontend:/app
       - /app/node_modules

--- a/docs/product_backlog.md
+++ b/docs/product_backlog.md
@@ -175,6 +175,7 @@ The goal of this release was to build a robust and user-friendly system for impo
 -   **Capital Gains Report (FR10):** Generate Short-Term (STCG), Long-Term (LTCG), and Schedule 112A reports. **✅ Complete**
 -   **Foreign Assets Reporting (Schedule FA):** Peak Value tracking and Calendar Year reporting. **✅ Complete**
 -   **Symbol Alias Management (#215):** Admin UI to view, create, edit, and delete symbol aliases used during data import. **✅ Complete**
+-   **ICICI ShortName Alias Seeding (#216):** Auto-create ICICI ShortName → Ticker aliases during asset seeding for seamless tradebook imports. **✅ Complete**
 -   **Automated Data Import - Phase 3 (FR7):** Implement a parser for Consolidated Account Statements (MF CAS).
 -   **Forgotten Password Flow (FR1.6):** Implement a secure password reset mechanism.
 

--- a/docs/workflow_history.md
+++ b/docs/workflow_history.md
@@ -1,3 +1,35 @@
+## 2026-02-16: Auto-Create ICICI ShortName Aliases During Asset Seeding (#216)
+
+**Task:** Automatically map ICICI Direct's internal ShortName to the exchange ticker during asset seeding, so ICICI tradebook imports no longer require manual alias mapping.
+
+**AI Assistant:** Antigravity
+**Role:** Backend Developer
+
+### Summary
+
+Modified the ICICI fallback seeder (`_process_fallback_row`) to read the `ShortName` column from the SecurityMaster CSV. When `ShortName` differs from the resolved ticker (ExchangeCode/ScripID), an `AssetAlias` is auto-created with source `"ICICI Direct Tradebook"`.
+
+Key changes:
+-   `_create_asset` → returns `Optional[Asset]` instead of `bool`.
+-   New `_create_alias` helper with deduplication logic.
+-   `alias_count` counter added to `AssetSeeder.__init__`.
+
+### File Changes
+
+**Backend:**
+*   **Modified:** `backend/app/services/asset_seeder.py` — Core implementation
+*   **New:** `backend/app/tests/services/test_icici_alias_seeding.py` — 5 unit tests
+
+### Verification
+
+*   **Tests:** 5/5 passed (alias created, no alias when matching/missing/NaN, dedup on re-seed).
+
+### Outcome
+
+**Success.** ICICI tradebook imports will auto-resolve ShortName → Ticker via seeded aliases. Closes #216.
+
+---
+
 ## 2026-02-15: Add Admin UI for Symbol Alias Management (#215)
 
 **Task:** Implement full CRUD (create, read, update, delete) for symbol aliases, accessible from the Admin section. Previously, aliases could only be created during import but never viewed, edited, or deleted.

--- a/frontend/src/services/adminApi.ts
+++ b/frontend/src/services/adminApi.ts
@@ -91,8 +91,17 @@ export interface AssetAliasUpdate {
   asset_id?: string;
 }
 
-export const getAliases = async (): Promise<AssetAliasWithAsset[]> => {
-  const response = await apiClient.get('/api/v1/admin/aliases/');
+export interface AliasPageResponse {
+  items: AssetAliasWithAsset[];
+  total: number;
+}
+
+export const getAliases = async (params?: {
+  q?: string;
+  skip?: number;
+  limit?: number;
+}): Promise<AliasPageResponse> => {
+  const response = await apiClient.get('/api/v1/admin/aliases/', { params });
   return response.data;
 };
 


### PR DESCRIPTION
Enhances Symbol Alias management with search/pagination and fixes critical seeding issues for ICICI/NSE data.

## What's Changed

### 1. Symbol Alias Search & Pagination
- **Backend**: Added `search_with_assets` CRUD method with ILIKE search (alias, source, ticker, name). API now returns `{items: [...], total: N}`.
- **Frontend**: Added debounced search bar, result count, and pagination controls to `AdminAliasesPage`.

### 2. NSE Seeding & Parsing Fixes
- **Issue**: NSE aliases were effectively skipped because `NSEScripMaster.txt` used comma-space delimiters, causing empty rows, and `_create_asset` returned None for pre-existing assets.
- **Fix**:
    - Stripped whitespace from column names and string values after reading CSV.
    - Updated `_process_fallback_row` to look up existing assets (by ISIN/Ticker) when `create_asset` returns None, ensuring aliases are always created.

### 3. Asset Search Modal Fix
- **Issue**: Alias update/create modal was 404ing on `/api/v1/admin/assets/search-local`.
- **Fix**: Added missing `/search-local` endpoint to `admin_assets.py`.

### 4. Tests
- Added `test_admin_assets.py` for new search endpoint.
- Added `test_icici_alias_seeding.py` covering alias logic.
- Updated `test_admin_aliases.py` for new paginated response format.

## Verification
- AI Verified: All 12 relevant tests passed.
- End-to-end flow verified: Seeding -> Alias Creation -> Import Resolution.
