### PR TITLE
🛡️ Sentinel: [CRITICAL] Remove hardcoded SECRET_KEY default

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -5,7 +5,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    SECRET_KEY: str = "a_super_secret_key_that_should_be_changed"
+    SECRET_KEY: str
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
 


### PR DESCRIPTION
🚨 **Severity: CRITICAL**

**Vulnerability:**
The `SECRET_KEY` used for signing JWT tokens had a hardcoded default value in `backend/app/core/config.py`. If an administrator deployed the application without explicitly setting the `SECRET_KEY` environment variable, the application would silently fall back to this known default value.

**Impact:**
An attacker aware of this default key could forge valid JWT access tokens for any user (including admins), leading to full account takeover and data compromise.

**Fix:**
Removed the default value for `SECRET_KEY` in the `Settings` class. The application will now raise a `pydantic.ValidationError` and crash at startup if `SECRET_KEY` is not provided in the environment or `.env` file.

**Verification:**
- Verified that `backend/app/core/config.py` no longer contains the default string.
- Ran the full test suite (`./run_local_tests.sh all`) which passed successfully (the test runner injects a dummy key).
- Confirmed that this change forces secure configuration practices.

---
*PR created automatically by Jules for task [15938239952054744657](https://jules.google.com/task/15938239952054744657) started by @aashishbhanawat*