### PR TITLE
⚡ Fix N+1 query in Schedule FA Service

### DIFF
--- a/backend/app/services/schedule_fa_service.py
+++ b/backend/app/services/schedule_fa_service.py
@@ -11,7 +11,7 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import Dict, List, Optional, Tuple
 
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from app.models import Asset, Transaction
 from app.schemas.enums import TransactionType
@@ -146,6 +146,7 @@ class ScheduleFAService:
         query = (
             self.db.query(Transaction)
             .join(Asset)
+            .options(joinedload(Transaction.sell_links))
             .filter(
                 Transaction.user_id == user_id,
                 Asset.currency != "INR",


### PR DESCRIPTION
This PR addresses a performance issue in `ScheduleFAService._get_foreign_lots_for_period` where `Transaction.sell_links` were being lazily loaded inside a loop, causing N+1 database queries.

### Changes
- Added `.options(joinedload(Transaction.sell_links))` to the SQLAlchemy query in `backend/app/services/schedule_fa_service.py`.
- This ensures `sell_links` are fetched in the initial query (or a single additional query depending on loading strategy, though `joinedload` does a join).

### Verification
- Created a reproduction script `backend/reproduce_issue.py` (deleted before commit).
- **Baseline:** 52 queries for 50 SELL transactions.
- **Improved:** 2 queries for 50 SELL transactions.
- Ran existing unit tests `backend/app/tests/services/test_schedule_fa_service.py` and they passed.
- Ran `ruff check` on the modified file.

---
*PR created automatically by Jules for task [18136021857551880155](https://jules.google.com/task/18136021857551880155) started by @aashishbhanawat*