### PR TITLE
⚡ Bolt: Optimize holding calculation by removing O(N) asset scans

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-18 - [O(N) vs O(NxM) in Holding Calculation]
+**Learning:** The application was performing linear scans of `asset_map` values to find assets by ticker symbol inside loops iterating over holdings. This resulted in O(N*M) complexity where N is holdings and M is total assets.
+**Action:** Create auxiliary maps (like `ticker_map`) immediately after fetching bulk data to ensure O(1) lookups for secondary keys.


### PR DESCRIPTION
⚡ Bolt: Optimize holding calculation by removing O(N) asset scans

💡 What:
Replaced repeated linear scans of the `asset_map` values with a `ticker_map` (dictionary keyed by ticker symbol) for O(1) lookups in `backend/app/crud/crud_holding.py`.

🎯 Why:
The previous implementation iterated through all assets in the portfolio (M) for every holding ticker (N) during enrichment, FX rate fetching, and final list construction. This resulted in O(N * M) complexity. With many assets, this becomes a bottleneck.

📊 Impact:
Reduces the algorithmic complexity of the holdings processing loop from O(N * M) to O(N). Lookups are now constant time.

🔬 Measurement:
Verified by running `test_holding_characterization.py` and `test_foreign_assets.py`. The logic remains functionally identical but significantly faster for large portfolios.

---
*PR created automatically by Jules for task [2087163045177563943](https://jules.google.com/task/2087163045177563943) started by @aashishbhanawat*