### PR TITLE
⚡ Bolt: Memoize HoldingsTable to prevent re-renders

### DIFF
--- a/frontend/src/components/Portfolio/HoldingsTable.tsx
+++ b/frontend/src/components/Portfolio/HoldingsTable.tsx
@@ -201,4 +201,6 @@ const HoldingsTable: React.FC<HoldingsTableProps> = ({ holdings, isLoading, erro
     );
 };
 
-export default HoldingsTable;
+// Memoized to prevent unnecessary re-renders when parent state changes (e.g. modals opening)
+// but holdings data remains the same.
+export default React.memo(HoldingsTable);

--- a/frontend/src/pages/Portfolio/PortfolioDetailPage.tsx
+++ b/frontend/src/pages/Portfolio/PortfolioDetailPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { usePortfolio, usePortfolioAnalytics, usePortfolioSummary, usePortfolioHoldings, useDeleteTransaction, useDeleteBond } from '../../hooks/usePortfolios';
 import { useDeleteFixedDeposit } from '../../hooks/useFixedDeposits';
@@ -57,13 +57,14 @@ const PortfolioDetailPage: React.FC = () => {
         }
     }, [holdings, selectedHolding]);
 
+    // Memoize the handler to prevent re-rendering HoldingsTable when other state changes
+    const handleHoldingClick = useCallback((holding: Holding) => {
+        setSelectedHolding(holding);
+    }, []);
+
     if (isLoading) return <div className="text-center p-8">Loading portfolio details...</div>;
     if (isError) return <div className="text-center p-8 text-red-500">Error: {error.message}</div>;
     if (!portfolio) return <div className="text-center p-8">Portfolio not found.</div>;
-
-    const handleHoldingClick = (holding: Holding) => {
-        setSelectedHolding(holding);
-    };
 
     const handleCloseDetailModal = () => {
         setSelectedHolding(null);


### PR DESCRIPTION
Memoized `HoldingsTable` to prevent unnecessary re-renders when parent state changes. This involved wrapping `HoldingsTable` in `React.memo` and ensuring `onRowClick` prop is stable by using `useCallback` in `PortfolioDetailPage`.

---
*PR created automatically by Jules for task [11345200996932315556](https://jules.google.com/task/11345200996932315556) started by @aashishbhanawat*