### PR TITLE
🎨 Palette: Improve Toast accessibility and stacking

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,10 @@
+## 2024-05-22 - Toast Stacking and Accessibility
+**Learning:** The existing `Toast` component was using `fixed` positioning, which caused multiple toasts to overlap perfectly instead of stacking.
+**Action:** When creating notification lists, ensure the container handles positioning (e.g., `fixed top-right`) and individual items are `relative` or `static` block elements to allow natural stacking. Also, verify `role="alert"`/`status` and `aria-live` for screen readers.
+
+## 2024-05-22 - Playwright Verification with HashRouter and Auth
+**Learning:** The app uses `HashRouter` and has a strict auth check on load that fails if the backend is down.
+**Action:** To verify frontend components in isolation without backend:
+1. Navigate using hash routes (e.g., `/#/my-route`).
+2. Clear `localStorage` to prevent auto-login attempts that trigger errors.
+3. Use `text=` locators carefully when elements contain icons/buttons (like "×").

--- a/frontend/src/__tests__/components/common/Toast.test.tsx
+++ b/frontend/src/__tests__/components/common/Toast.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Toast from '../../../components/common/Toast';
+
+describe('Toast Component', () => {
+  const mockOnClose = jest.fn();
+
+  beforeEach(() => {
+    mockOnClose.mockClear();
+  });
+
+  it('renders success toast with correct accessibility attributes', () => {
+    render(
+      <Toast
+        message="Operation successful"
+        type="success"
+        onClose={mockOnClose}
+      />
+    );
+
+    const toast = screen.getByRole('status');
+    expect(toast).toBeInTheDocument();
+    expect(toast).toHaveTextContent('Operation successful');
+    expect(toast).toHaveClass('bg-green-500');
+    // Polite announcement for success
+    // Note: jest-dom doesn't automatically check aria-live value with getByRole,
+    // so we check attribute explicitly if needed, but getByRole('status') implies implicit aria behaviors.
+    // However, explicitly checking attribute is good.
+    expect(toast).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('renders error toast with correct accessibility attributes', () => {
+    render(
+      <Toast
+        message="Operation failed"
+        type="error"
+        onClose={mockOnClose}
+      />
+    );
+
+    const toast = screen.getByRole('alert');
+    expect(toast).toBeInTheDocument();
+    expect(toast).toHaveTextContent('Operation failed');
+    expect(toast).toHaveClass('bg-red-500');
+    // Assertive announcement for errors
+    expect(toast).toHaveAttribute('aria-live', 'assertive');
+  });
+
+  it('renders close button with aria-label', () => {
+    render(
+      <Toast
+        message="Test message"
+        type="success"
+        onClose={mockOnClose}
+      />
+    );
+
+    const closeButton = screen.getByRole('button', { name: /close/i });
+    expect(closeButton).toBeInTheDocument();
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    render(
+      <Toast
+        message="Test message"
+        type="success"
+        onClose={mockOnClose}
+      />
+    );
+
+    const closeButton = screen.getByRole('button', { name: /close/i });
+    fireEvent.click(closeButton);
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/common/Toast.tsx
+++ b/frontend/src/components/common/Toast.tsx
@@ -7,16 +7,28 @@ interface ToastProps {
 }
 
 const Toast: React.FC<ToastProps> = ({ message, type, onClose }) => {
-  const baseClasses = 'fixed top-5 right-5 p-4 rounded-lg shadow-lg text-white flex justify-between items-center';
+  // Removed fixed positioning so toasts can stack naturally in the container
+  const baseClasses = 'mb-3 w-80 p-4 rounded-lg shadow-lg text-white flex justify-between items-center transition-all duration-300';
   const typeClasses = {
     success: 'bg-green-500',
     error: 'bg-red-500',
   };
 
+  const role = type === 'error' ? 'alert' : 'status';
+  const ariaLive = type === 'error' ? 'assertive' : 'polite';
+
   return (
-    <div className={`${baseClasses} ${typeClasses[type]}`}>
+    <div
+      className={`${baseClasses} ${typeClasses[type]}`}
+      role={role}
+      aria-live={ariaLive}
+    >
       <span>{message}</span>
-      <button onClick={onClose} className="ml-4 font-bold">
+      <button
+        onClick={onClose}
+        className="ml-4 font-bold focus:outline-none focus:ring-2 focus:ring-white/50 rounded"
+        aria-label="Close"
+      >
         &times;
       </button>
     </div>


### PR DESCRIPTION
💡 **What:**
Improved the `Toast` component by fixing a stacking issue where multiple notifications would overlap. Enhanced accessibility by adding ARIA roles (`alert`, `status`) and labels.

🎯 **Why:**
- **UX:** Users could not see multiple notifications if they arrived simultaneously because they were rendered on top of each other.
- **Accessibility:** Screen readers did not announce toast messages correctly, and the close button lacked a label.

📸 **Before/After:**
The toasts now stack vertically in the top-right corner with proper spacing, instead of overlapping.

♿ **Accessibility:**
- Added `role="alert"` for error toasts and `role="status"` for success toasts.
- Added `aria-live="assertive"`/`polite` for automatic announcements.
- Added `aria-label="Close"` to the dismiss button.
- Verified with unit tests.

---
*PR created automatically by Jules for task [11835781138949180671](https://jules.google.com/task/11835781138949180671) started by @aashishbhanawat*