### PR TITLE
chore: remove unused lxml and pyinstaller from production deps

### DIFF
--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -22,11 +22,9 @@ cryptography
 pyxirr
 numpy
 pyarrow
-pyinstaller
 requests
 openpyxl
 xlrd
-lxml
 pdfplumber
 
 # Security fixes for transitive dependencies

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,8 +6,6 @@
 #
 alembic==1.18.4
     # via -r requirements.in
-altgraph==0.17.5
-    # via pyinstaller
 annotated-doc==0.0.4
     # via
     #   fastapi
@@ -84,8 +82,6 @@ idna==3.11
     #   requests
 iniconfig==2.3.0
     # via pytest
-lxml==6.0.2
-    # via -r requirements.in
 mako==1.3.10
     # via alembic
 markdown-it-py==4.0.0
@@ -104,10 +100,7 @@ numpy==2.4.2
 openpyxl==3.1.5
     # via -r requirements.in
 packaging==26.0
-    # via
-    #   pyinstaller
-    #   pyinstaller-hooks-contrib
-    #   pytest
+    # via pytest
 pandas==3.0.0
     # via yfinance
 passlib[bcrypt]==1.7.4
@@ -151,10 +144,6 @@ pygments==2.19.2
     # via
     #   pytest
     #   rich
-pyinstaller==6.18.0
-    # via -r requirements.in
-pyinstaller-hooks-contrib==2026.0
-    # via pyinstaller
 pypdfium2==5.4.0
     # via pdfplumber
 pytest==9.0.2


### PR DESCRIPTION
Closes #219

## Audit Results
Scanned all imports (direct and indirect) across the entire backend codebase. Out of 28 packages in `requirements.in`, found **2 removable**:

### Removed
- **`lxml`** — not imported anywhere in the codebase, not used as a parser engine
- **`pyinstaller`** — build tool, already listed in `requirements-dev.in`

### Transitive deps also removed from `requirements.txt`
- `altgraph` (only dep: pyinstaller)
- `pyinstaller-hooks-contrib` (only dep: pyinstaller)
- Updated `packaging` via comment (removed pyinstaller references)

### All other packages confirmed used
Verified every remaining package has active imports or is used as a library engine (e.g., `openpyxl` for xlsx, `xlrd` for xls, `pyarrow` for parquet).