### PR TITLE
perf: lazy load import parsers to reduce startup time/size

### DIFF
--- a/backend/app/services/import_parsers/icici_demat_dividend_parser.py
+++ b/backend/app/services/import_parsers/icici_demat_dividend_parser.py
@@ -8,10 +8,6 @@ import re
 from datetime import datetime
 from typing import List, Optional
 
-import pdfplumber
-from pdfminer.pdfdocument import PDFPasswordIncorrect
-from pdfminer.pdfparser import PDFSyntaxError
-
 from app.schemas.import_session import ParsedTransaction
 
 from .base_parser import BaseParser
@@ -44,6 +40,10 @@ class IciciDematDividendParser(BaseParser):
         Returns:
             List of ParsedTransaction objects (DIVIDEND type)
         """
+        import pdfplumber
+        from pdfminer.pdfdocument import PDFPasswordIncorrect
+        from pdfminer.pdfparser import PDFSyntaxError
+
         transactions = []
 
         try:

--- a/backend/app/services/import_parsers/icici_securities_parser.py
+++ b/backend/app/services/import_parsers/icici_securities_parser.py
@@ -8,10 +8,6 @@ import re
 from datetime import datetime
 from typing import List, Optional, Tuple
 
-import pdfplumber
-from pdfminer.pdfdocument import PDFPasswordIncorrect
-from pdfminer.pdfparser import PDFSyntaxError
-
 from app.schemas.import_session import ParsedTransaction
 
 from .base_parser import BaseParser
@@ -73,6 +69,10 @@ class ICICISecuritiesParser(BaseParser):
         """
         transactions = []
         current_scheme = None
+
+        import pdfplumber
+        from pdfminer.pdfdocument import PDFPasswordIncorrect
+        from pdfminer.pdfparser import PDFSyntaxError
 
         try:
             with pdfplumber.open(file_path, password=password) as pdf:

--- a/backend/app/services/import_parsers/kfintech_parser.py
+++ b/backend/app/services/import_parsers/kfintech_parser.py
@@ -9,25 +9,11 @@ import re
 from datetime import datetime
 from typing import List, Optional
 
-import pdfplumber
-from pdfminer.pdfdocument import PDFPasswordIncorrect
-
-# pdfplumber.utils.exceptions may not be bundled correctly by PyInstaller
-# Use a fallback exception class if the module is unavailable
-try:
-    from pdfplumber.utils.exceptions import PdfminerException
-except ImportError:
-    # Fallback: catch generic Exception in the parse method
-    PdfminerException = Exception
-
 from app.schemas.import_session import ParsedTransaction
 
 from .base_parser import BaseParser
 
 logger = logging.getLogger(__name__)
-
-# Silence pdfminer's extremely verbose debug logging
-logging.getLogger("pdfminer").setLevel(logging.WARNING)
 
 
 class KFintechParser(BaseParser):
@@ -173,6 +159,20 @@ class KFintechParser(BaseParser):
             ValueError: If password is required but not provided
         """
         transactions = []
+
+        import pdfplumber
+        from pdfminer.pdfdocument import PDFPasswordIncorrect
+
+        # Silence pdfminer's extremely verbose debug logging
+        logging.getLogger("pdfminer").setLevel(logging.WARNING)
+
+        # pdfplumber.utils.exceptions may not be bundled correctly by PyInstaller
+        # Use a fallback exception class if the module is unavailable
+        try:
+            from pdfplumber.utils.exceptions import PdfminerException
+        except ImportError:
+            # Fallback: catch generic Exception in the parse method
+            PdfminerException = Exception
 
         try:
             with pdfplumber.open(file_path, password=password or "") as pdf:

--- a/backend/app/services/import_parsers/parser_factory.py
+++ b/backend/app/services/import_parsers/parser_factory.py
@@ -1,44 +1,46 @@
 from .base_parser import BaseParser
-from .cams_parser import CamsParser
-from .generic_parser import GenericCsvParser
-from .icici_demat_dividend_parser import IciciDematDividendParser
-from .icici_parser import IciciParser
-from .icici_portfolio_parser import IciciPortfolioParser
-from .icici_securities_parser import ICICISecuritiesParser
-from .kfintech_parser import KFintechParser
-from .kfintech_xls_parser import KFintechXlsParser
-from .mfcentral_parser import MfCentralParser
-from .zerodha_coin_parser import ZerodhaCoinParser
-from .zerodha_dividend_parser import ZerodhaDividendParser
-from .zerodha_parser import ZerodhaParser
 
 
 def get_parser(source_type: str) -> BaseParser:
+    """Return the appropriate parser for the given source type.
+
+    Parsers are lazily imported to avoid loading heavy libraries
+    (pdfplumber, pdfminer, pandas, openpyxl) at application startup.
+    """
     if source_type == "Zerodha Tradebook":
+        from .zerodha_parser import ZerodhaParser
         return ZerodhaParser()
     elif source_type == "ICICI Direct Tradebook":
+        from .icici_parser import IciciParser
         return IciciParser()
     elif source_type == "ICICI Direct Portfolio Equity":
+        from .icici_portfolio_parser import IciciPortfolioParser
         return IciciPortfolioParser()
     elif source_type == "MFCentral CAS":
+        from .mfcentral_parser import MfCentralParser
         return MfCentralParser()
     elif source_type == "CAMS Statement":
+        from .cams_parser import CamsParser
         return CamsParser()
     elif source_type == "Zerodha Coin":
+        from .zerodha_coin_parser import ZerodhaCoinParser
         return ZerodhaCoinParser()
     elif source_type == "KFintech Statement":
+        from .kfintech_parser import KFintechParser
         return KFintechParser()
     elif source_type == "KFintech XLS":
+        from .kfintech_xls_parser import KFintechXlsParser
         return KFintechXlsParser()
     elif source_type == "ICICI Securities MF":
+        from .icici_securities_parser import ICICISecuritiesParser
         return ICICISecuritiesParser()
     elif source_type == "Zerodha Dividend":
+        from .zerodha_dividend_parser import ZerodhaDividendParser
         return ZerodhaDividendParser()
     elif source_type == "ICICI DEMAT Dividend":
+        from .icici_demat_dividend_parser import IciciDematDividendParser
         return IciciDematDividendParser()
     # Add other parsers here in the future
     else:
+        from .generic_parser import GenericCsvParser
         return GenericCsvParser()
-
-
-


### PR DESCRIPTION
Closes #218

## Problem
The desktop app bundle (and backend server) was eager-loading all 12 import parsers at startup via `parser_factory.py`. This pulled in heavy libraries (`pdfplumber`, `pdfminer`, `pandas`, `openpyxl`, etc.) even when no import functionality was being used, increasing startup time and memory footprint.

## Solution
Implemented lazy loading across the parser infrastructure:
1. **Parser Factory**: Refactored `parser_factory.py` to import parser classes inside the `get_parser()` function branches. Now, only the specific parser needed for a source type is imported.
2. **PDF Parsers**: Moved `pdfplumber` and `pdfminer` imports inside the `parse()` methods of the 3 PDF parsers (`icici_demat_dividend_parser`, `icici_securities_parser`, `kfintech_parser`).

## Verification
- ✅ `pytest` passes locally (ensuring imports resolve correctly during parsing)
- ✅ `ruff` linting passes
- ✅ Heavy libraries are no longer loaded into memory until an import session begins