### PR TITLE
⚡ Bolt: [performance improvement] O(1) lookup for transaction lots mapping

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-18 - [O(N) vs O(NxM) in Holding Calculation]
 **Learning:** The application was performing linear scans of `asset_map` values to find assets by ticker symbol inside loops iterating over holdings. This resulted in O(N*M) complexity where N is holdings and M is total assets.
 **Action:** Create auxiliary maps (like `ticker_map`) immediately after fetching bulk data to ensure O(1) lookups for secondary keys.
+
+## 2025-02-18 - [O(1) Python object reference tracking in Arrays vs Dicts]
+**Learning:** In python, you can index a dictionary for quick O(1) loopups while preserving the same memory references used in an array/list. This helps lower algorithm complexity for searches inside loops down from O(N*M) to O(N), without affecting logic that relies on list-order iteration down the line.
+**Action:** Initialize a `lots_map` inside loops updating `available_quantity` attributes and retrieve them for updating to reduce time complexity without impacting functionality that relies on FIFO list processing.

--- a/backend/app/crud/crud_transaction.py
+++ b/backend/app/crud/crud_transaction.py
@@ -471,16 +471,17 @@ class CRUDTransaction(CRUDBase[Transaction, TransactionCreate, TransactionUpdate
                 links_map[link.sell_transaction_id].append(link)
 
         lots = []  # List of buys: {tx, available_quantity}
+        lots_map = {}  # O(1) lookup map from buy_transaction_id to lot dict
 
         for tx in transactions:
             if tx.transaction_type in ["BUY", "ESPP_PURCHASE", "RSU_VEST"]:
-                lots.append(
-                    {
-                        "transaction": tx,
-                        "available_quantity": tx.quantity,
-                        "date": tx.transaction_date,
-                    }
-                )
+                lot = {
+                    "transaction": tx,
+                    "available_quantity": tx.quantity,
+                    "date": tx.transaction_date,
+                }
+                lots.append(lot)
+                lots_map[tx.id] = lot
             elif tx.transaction_type == "SELL":
                 # Skip the excluded sell (used during auto-linking)
                 if exclude_sell_id and tx.id == exclude_sell_id:
@@ -496,11 +497,11 @@ class CRUDTransaction(CRUDBase[Transaction, TransactionCreate, TransactionUpdate
                     linked_buy_ids[link.buy_transaction_id] = link.quantity
                     sell_qty -= link.quantity
 
-                    # Deduct from the specific lot
-                    for lot in lots:
-                        if lot["transaction"].id == link.buy_transaction_id:
-                            lot["available_quantity"] -= link.quantity
-                            break
+                    # Deduct from the specific lot using O(1) lookup
+                    if link.buy_transaction_id in lots_map:
+                        lots_map[link.buy_transaction_id][
+                            "available_quantity"
+                        ] -= link.quantity
 
                 # 2. Process Remaining Quantity (Unlinked) via FIFO
                 if sell_qty > 0:

--- a/backend/app/scripts/backfill_transaction_links.py
+++ b/backend/app/scripts/backfill_transaction_links.py
@@ -46,15 +46,18 @@ def get_available_lots_for_backfill(
     )
 
     lots = []
+    lots_map = {}  # O(1) lookup map from buy_transaction_id to lot dict
 
     for tx in transactions:
         if tx.transaction_type in ["BUY", "ESPP_PURCHASE", "RSU_VEST", "BONUS"]:
-            lots.append({
+            lot = {
                 "id": tx.id,
                 "available_quantity": tx.quantity,
                 "date": tx.transaction_date,
                 "price_per_unit": tx.price_per_unit,
-            })
+            }
+            lots.append(lot)
+            lots_map[tx.id] = lot
         elif tx.transaction_type == "SELL":
             sell_qty = tx.quantity
 
@@ -66,10 +69,11 @@ def get_available_lots_for_backfill(
             )
             for link in links:
                 sell_qty -= link.quantity
-                for lot in lots:
-                    if lot["id"] == link.buy_transaction_id:
-                        lot["available_quantity"] -= link.quantity
-                        break
+                # Deduct from the specific lot using O(1) lookup
+                if link.buy_transaction_id in lots_map:
+                    lots_map[link.buy_transaction_id][
+                        "available_quantity"
+                    ] -= link.quantity
 
             # 2. Process unlinked quantity via FIFO
             if sell_qty > 0:


### PR DESCRIPTION
💡 **What**:
Replaced an O(M) list scanning process with an O(1) dictionary hash lookup when applying specific transaction links during SELL logic in `get_available_lots`.

🎯 **Why**:
When matching specific links against BUY transactions, the logic iterated over all `lots` inside a loop iterating over all `links`, causing O(N*M) algorithmic complexity. For portfolios with thousands of lots and links, this lookup could scale quadratically and create performance bottlenecks during capital gain processing, backfills, and history loading.

📊 **Impact**:
Eliminates an inner loop structure entirely and replaces it with a simple, constant-time Python lookup (`link.buy_transaction_id in lots_map`). Time complexity reduced from O(N*M) to O(N).

🔬 **Measurement**:
Unit tests running in `test_tax_lot_accounting_flow.py` prove the logic functionality remains exactly identical, retaining FIFO processing. Run `./run_local_tests.sh backend` to verify.

---
*PR created automatically by Jules for task [11229044837930748510](https://jules.google.com/task/11229044837930748510) started by @aashishbhanawat*