### PR TITLE
🎨 Palette: Auto-focus Cancel button on DeleteConfirmationModal

### DIFF
--- a/frontend/src/components/common/DeleteConfirmationModal.tsx
+++ b/frontend/src/components/common/DeleteConfirmationModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 interface DeleteConfirmationModalProps {
   isOpen: boolean;
@@ -17,6 +17,17 @@ export const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = (
   message,
   isDeleting,
 }) => {
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      const timer = setTimeout(() => {
+        cancelButtonRef.current?.focus();
+      }, 50);
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   return (
@@ -30,7 +41,7 @@ export const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = (
           <div className="text-gray-700 dark:text-gray-300 mb-4">{message}</div>
           <p className="text-sm text-red-500 dark:text-red-400 bg-red-100 dark:bg-red-900/30 p-3 rounded-md">This action is permanent and cannot be undone.</p>
           <div className="flex items-center justify-end pt-6">
-            <button type="button" onClick={onClose} className="btn btn-secondary mr-2" disabled={isDeleting}>Cancel</button>
+            <button type="button" ref={cancelButtonRef} onClick={onClose} className="btn btn-secondary mr-2" disabled={isDeleting}>Cancel</button>
             <button type="button" onClick={onConfirm} className="btn btn-danger" disabled={isDeleting}>{isDeleting ? 'Deleting...' : 'Confirm Delete'}</button>
           </div>
         </div>


### PR DESCRIPTION
**💡 What:** Added auto-focus to the 'Cancel' button on the `DeleteConfirmationModal` component.
**🎯 Why:** To prevent users from accidentally triggering permanent, destructive actions (like deleting an item) by pressing 'Enter' or 'Space' when the modal is first shown. Auto-focusing the safer option is a recognized UX/accessibility pattern.
**📸 Before/After:** See the attached screenshot from testing that shows the focus outline on the 'Cancel' button.
**♿ Accessibility:** Enhances keyboard accessibility and interaction safety by defaulting the focus to the safest action within a destructive modal dialog.

---
*PR created automatically by Jules for task [432415348298030961](https://jules.google.com/task/432415348298030961) started by @aashishbhanawat*