### PR TITLE
⚡ Bolt: [performance improvement] Fix N+1 locking read in PPF holdings

### DIFF
--- a/backend/app/crud/crud_holding.py
+++ b/backend/app/crud/crud_holding.py
@@ -802,11 +802,17 @@ class CRUDHolding:
         ]
         logger.info(f"Found {len(ppf_assets)} PPF assets to process.")
         # --- PPF Holdings ---
+
+        if ppf_assets:
+            # Lock all PPF asset rows at once before processing to prevent race
+            # conditions on the interest calculation logic, which has a write
+            # side-effect. This is only supported by PostgreSQL.
+            ppf_asset_ids = [asset.id for asset in ppf_assets]
+            db.query(models.Asset).filter(
+                models.Asset.id.in_(ppf_asset_ids)
+            ).with_for_update().all()
+
         for ppf_asset in ppf_assets:
-            # Lock the asset row before processing to prevent race conditions
-            # on the interest calculation logic, which has a write side-effect.
-            # This is only supported by PostgreSQL.
-            db.query(models.Asset).filter_by(id=ppf_asset.id).with_for_update().first()
             logger.info(f"Processing PPF asset {ppf_asset.id}...")
             ppf_holding = process_ppf_holding(db, ppf_asset, portfolio_id)
             if ppf_holding:


### PR DESCRIPTION
💡 **What:**
Replaced the individual row-locking query inside the `ppf_assets` processing loop with a single batch-locking query using an `.in_()` clause before the loop begins.

🎯 **Why:**
The previous implementation performed an N+1 locking read (`db.query(...).filter_by(id=ppf_asset.id).with_for_update().first()`), sending N separate queries to the database to lock rows. Locking multiple rows individually in a loop can lead to deadlocks and severe performance degradation, especially for portfolios with many PPF assets. 

📊 **Measured Improvement:**
Created a local benchmark script (`test_perf.py`) generating a portfolio with 100 PPF assets to exaggerate the problem.
- **Baseline:** 1508 total queries.
- **Optimized:** 1409 total queries.
- **Change:** A reduction of ~100 queries (exactly 1 query eliminated per PPF asset). Performance scales down linearly O(1) locking query vs O(N) locking queries.

---
*PR created automatically by Jules for task [14076666737585111729](https://jules.google.com/task/14076666737585111729) started by @aashishbhanawat*