### PR TITLE
🎨 Palette: Improve error message consistency in Interest Rate Form Modal

### DIFF
--- a/frontend/src/components/Admin/InterestRateFormModal.tsx
+++ b/frontend/src/components/Admin/InterestRateFormModal.tsx
@@ -66,14 +66,14 @@ const InterestRateFormModal: React.FC<InterestRateFormModalProps> = ({ isOpen, o
           <form onSubmit={handleSubmit(onSubmit)}>
             <div className="form-group">
               <label htmlFor="scheme_name" className="form-label">Scheme Name</label>
-              <input id="scheme_name" type="text" {...register('scheme_name', { required: 'Scheme name is required' })} className="form-input" required disabled={isPending} />
-              {errors.scheme_name && <p className="form-error">{errors.scheme_name.message}</p>}
+              <input id="scheme_name" type="text" {...register('scheme_name', { required: 'Scheme name is required' })} className="form-input" required disabled={isPending} aria-invalid={!!errors.scheme_name} aria-describedby={errors.scheme_name ? "scheme_name_error" : undefined} />
+              {errors.scheme_name && <p id="scheme_name_error" className="text-red-500 text-xs italic mt-1" role="alert">{errors.scheme_name.message}</p>}
             </div>
             <div className="grid grid-cols-2 gap-4">
               <div className="form-group">
                 <label htmlFor="start_date" className="form-label">Start Date</label>
-                <input id="start_date" type="date" {...register('start_date', { required: 'Start date is required' })} className="form-input" required disabled={isPending} />
-                {errors.start_date && <p className="form-error">{errors.start_date.message}</p>}
+                <input id="start_date" type="date" {...register('start_date', { required: 'Start date is required' })} className="form-input" required disabled={isPending} aria-invalid={!!errors.start_date} aria-describedby={errors.start_date ? "start_date_error" : undefined} />
+                {errors.start_date && <p id="start_date_error" className="text-red-500 text-xs italic mt-1" role="alert">{errors.start_date.message}</p>}
               </div>
               <div className="form-group">
                 <label htmlFor="end_date" className="form-label">End Date (optional)</label>
@@ -82,8 +82,8 @@ const InterestRateFormModal: React.FC<InterestRateFormModalProps> = ({ isOpen, o
             </div>
             <div className="form-group">
               <label htmlFor="rate" className="form-label">Interest Rate (%)</label>
-              <input id="rate" type="number" step="0.01" {...register('rate', { required: 'Rate is required', valueAsNumber: true })} className="form-input" required disabled={isPending} />
-              {errors.rate && <p className="form-error">{errors.rate.message}</p>}
+              <input id="rate" type="number" step="0.01" {...register('rate', { required: 'Rate is required', valueAsNumber: true })} className="form-input" required disabled={isPending} aria-invalid={!!errors.rate} aria-describedby={errors.rate ? "rate_error" : undefined} />
+              {errors.rate && <p id="rate_error" className="text-red-500 text-xs italic mt-1" role="alert">{errors.rate.message}</p>}
             </div>
 
             {apiError && (


### PR DESCRIPTION
💡 **What:** Replaced the non-existent `form-error` CSS class with `text-red-500 text-xs italic mt-1` and added proper ARIA attributes to the `InterestRateFormModal` inputs.
🎯 **Why:** To improve the visibility and consistency of validation errors in the Interest Rate Modal and to make them fully accessible to screen readers, aligning with the app's standard design and a11y patterns.
📸 **Before/After:** The error messages now display as distinct red italicized text directly beneath the input fields when validation fails, instead of inheriting generic text styles.
♿ **Accessibility:** Added `aria-invalid` and `aria-describedby` to the input fields, mapping them to the error message `id`s which now have `role="alert"`.

---
*PR created automatically by Jules for task [9418697783288418121](https://jules.google.com/task/9418697783288418121) started by @aashishbhanawat*