### PR TITLE
🎨 Palette: [UX improvement] Enhance Delete Modals Accessibility and Loading States

### DIFF
--- a/frontend/src/components/Goals/DeleteGoalModal.tsx
+++ b/frontend/src/components/Goals/DeleteGoalModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ArrowPathIcon } from '@heroicons/react/24/outline';
 
 interface DeleteGoalModalProps {
     isOpen: boolean;
@@ -13,21 +14,34 @@ const DeleteGoalModal: React.FC<DeleteGoalModalProps> = ({ isOpen, onClose, onCo
 
     return (
         <div className="modal-overlay">
-            <div className="modal-content max-w-md">
+            <div
+                className="modal-content max-w-md"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="delete-goal-modal-title"
+                aria-describedby="delete-goal-modal-desc"
+            >
                 <div className="modal-header">
-                    <h2 className="text-2xl font-bold">Delete Goal</h2>
-                    <button aria-label="Close" onClick={onClose} className="text-gray-400 hover:text-gray-600">&times;</button>
+                    <h2 id="delete-goal-modal-title" className="text-2xl font-bold">Delete Goal</h2>
+                    <button type="button" aria-label="Close" onClick={onClose} className="text-gray-400 hover:text-gray-600">&times;</button>
                 </div>
                 <div className="p-6">
-                    <p className="text-gray-600 mb-4">
+                    <p id="delete-goal-modal-desc" className="text-gray-600 mb-4">
                         Are you sure you want to delete the goal "<strong>{goalName}</strong>"? This action cannot be undone.
                     </p>
                     <div className="flex items-center justify-end pt-4">
-                        <button onClick={onClose} className="btn btn-secondary mr-2" disabled={isPending}>
+                        <button type="button" onClick={onClose} className="btn btn-secondary mr-2" disabled={isPending}>
                             Cancel
                         </button>
-                        <button onClick={onConfirm} className="btn btn-danger" disabled={isPending}>
-                            {isPending ? 'Deleting...' : 'Delete'}
+                        <button type="button" onClick={onConfirm} className="btn btn-danger flex items-center gap-2" disabled={isPending}>
+                            {isPending ? (
+                                <>
+                                    <ArrowPathIcon className="h-4 w-4 animate-spin" />
+                                    <span>Deleting...</span>
+                                </>
+                            ) : (
+                                'Delete'
+                            )}
                         </button>
                     </div>
                 </div>

--- a/frontend/src/components/Portfolio/DeletePortfolioModal.tsx
+++ b/frontend/src/components/Portfolio/DeletePortfolioModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ArrowPathIcon } from '@heroicons/react/24/outline';
 
 interface DeletePortfolioModalProps {
     isOpen: boolean;
@@ -13,13 +14,19 @@ const DeletePortfolioModal: React.FC<DeletePortfolioModalProps> = ({ isOpen, onC
 
     return (
         <div className="modal-overlay">
-            <div className="modal-content max-w-md" role="dialog" aria-modal="true" aria-labelledby="delete-modal-title">
+            <div
+                className="modal-content max-w-md"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="delete-modal-title"
+                aria-describedby="delete-modal-desc"
+            >
                 <div className="modal-header">
                     <h2 id="delete-modal-title" className="text-2xl font-bold text-red-600 dark:text-red-400">Delete Portfolio</h2>
                     <button aria-label="Close" onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">&times;</button>
                 </div>
                 <div className="p-6">
-                    <p className="text-gray-700 dark:text-gray-300 mb-4">
+                    <p id="delete-modal-desc" className="text-gray-700 dark:text-gray-300 mb-4">
                         Are you sure you want to delete the portfolio "<strong>{portfolioName}</strong>"?
                     </p>
                     <p className="text-sm text-red-500 dark:text-red-400 bg-red-100 dark:bg-red-900/30 p-3 rounded-md">
@@ -29,8 +36,15 @@ const DeletePortfolioModal: React.FC<DeletePortfolioModalProps> = ({ isOpen, onC
                         <button type="button" onClick={onClose} className="btn btn-secondary mr-2" disabled={isPending}>
                             Cancel
                         </button>
-                        <button type="button" onClick={onConfirm} className="btn btn-danger" disabled={isPending}>
-                            {isPending ? 'Deleting...' : 'Delete'}
+                        <button type="button" onClick={onConfirm} className="btn btn-danger flex items-center gap-2" disabled={isPending}>
+                            {isPending ? (
+                                <>
+                                    <ArrowPathIcon className="h-4 w-4 animate-spin" />
+                                    <span>Deleting...</span>
+                                </>
+                            ) : (
+                                'Delete'
+                            )}
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
🎨 Palette: [UX improvement] Enhance Delete Modals Accessibility and Loading States

💡 What: Added ARIA dialog roles, modal boolean tags, proper descriptive IDs, and visual loading spinners to `DeleteGoalModal` and `DeletePortfolioModal`.
🎯 Why: These modals were missing critical accessibility attributes needed by screen readers to understand they are dialogs and what they describe. Additionally, the delete buttons lacked visual feedback during asynchronous delete operations.
♿ Accessibility:
- Added `role="dialog"` and `aria-modal="true"`.
- Linked titles with `aria-labelledby`.
- Linked descriptions with `aria-describedby`.
- Added explicit `type="button"` to buttons.

---
*PR created automatically by Jules for task [11245919072622357365](https://jules.google.com/task/11245919072622357365) started by @aashishbhanawat*