### PR TITLE
feat(parsers): Handle KFintech Switch In/Out Merger transactions

### DIFF
--- a/backend/app/services/import_parsers/kfintech_parser.py
+++ b/backend/app/services/import_parsers/kfintech_parser.py
@@ -86,8 +86,6 @@ class KFintechParser(BaseParser):
         r"^Registrar",
         r"^ISIN:",
         r"^Advisor:",
-        r"^Switch.*Merger",  # TODO: Handle Switch In/Out - Merger later
-        r"^S\s*witch.*Merger",  # S witch Out - Merger
         r"^C\*\*",  # Corrupted text like "C**I*T SINT2T2"
         r"^\s*$",  # Empty lines
     ]

--- a/backend/app/tests/services/test_kfintech_parser.py
+++ b/backend/app/tests/services/test_kfintech_parser.py
@@ -27,12 +27,15 @@ class TestKFintechParser:
         assert parser._classify_transaction("Purchase") == "BUY"
         assert parser._classify_transaction("SIP Purchase") == "BUY"
         assert parser._classify_transaction("Switch In") == "BUY"
+        assert parser._classify_transaction("Switch In - Merger") == "BUY"
         assert parser._classify_transaction("Systematic Investment") == "BUY"
 
     def test_classify_transaction_sell(self, parser):
         """Test SELL transaction classification."""
         assert parser._classify_transaction("Redemption") == "SELL"
         assert parser._classify_transaction("Switch Out") == "SELL"
+        assert parser._classify_transaction("Switch Out - Merger") == "SELL"
+        assert parser._classify_transaction("S witch Out - Merger") == "SELL"
 
     def test_classify_transaction_dividend(self, parser):
         """Test dividend transaction classification."""
@@ -64,15 +67,13 @@ class TestKFintechParser:
         assert parser._should_skip("KYC : OK")
         assert parser._should_skip("Nominee 1 : Test")
 
-    def test_should_skip_merger(self, parser):
-        """Test merger transactions are skipped."""
-        assert parser._should_skip("Switch In - Merger")
-        assert parser._should_skip("Switch Out - Merger")
-
     def test_should_not_skip_transaction(self, parser):
         """Test transaction lines are not skipped."""
         assert not parser._should_skip("29-Nov-2021 Purchase 50000")
         assert not parser._should_skip("15-Jan-2022 SIP Purchase 2000")
+        assert not parser._should_skip("15-Jan-2022 Switch In - Merger 1000")
+        assert not parser._should_skip("15-Jan-2022 Switch Out - Merger 1000")
+        assert not parser._should_skip("15-Jan-2022 S witch Out - Merger 1000")
 
     def test_parse_number(self, parser):
         """Test number parsing with commas."""


### PR DESCRIPTION
### What
Updated the `kfintech_parser.py` to stop skipping "Switch In - Merger" and "Switch Out - Merger" (along with the garbled variant "S witch Out - Merger") transactions. 

### Why
Previously, these transactions were explicitly skipped in `KFintechParser.SKIP_PATTERNS`. Since MF mergers are complex (requiring selling the old fund and buying the new fund), these should be parsed as standard `BUY` (Switch In) and `SELL` (Switch Out) transactions, handing control over to the user to manage their holdings appropriately. 

### How
1. Removed `r"^Switch.*Merger"` and `r"^S\s*witch.*Merger"` from `KFintechParser.SKIP_PATTERNS`.
2. As confirmed by the user, these descriptions now seamlessly match the existing `r"^Switch\s*-?\s*In"` (mapped to `BUY`) and `r"^Switch\s*-?\s*Out"` / `r"^S\s*witch\s*-?\s*Out"` (mapped to `SELL`) patterns within `TRANSACTION_PATTERNS`.
3. Added test coverage in `test_kfintech_parser.py` to explicitly assert that these transaction descriptions are mapped correctly and no longer skipped.

### Verification
Ran tests against `test_kfintech_parser.py` successfully. All 11 tests passed in 0.05s. Evaluated regex matches via inline Python scripts to guarantee match fallback logic behaves correctly.

---
*PR created automatically by Jules for task [14309721614708147161](https://jules.google.com/task/14309721614708147161) started by @aashishbhanawat*