### PR TITLE
⚡ Bolt: Amortized O(1) lot lookup for Schedule FA FIFO logic

### DIFF
--- a/backend/app/services/schedule_fa_service.py
+++ b/backend/app/services/schedule_fa_service.py
@@ -171,6 +171,9 @@ class ScheduleFAService:
         lots_map = {}
         # Optimization: Map asset_id to list of lots for faster lookup
         lots_by_asset = defaultdict(list)
+        # Optimization: Track the persistent FIFO index pointer for each asset
+        # to achieve amortized O(1) lot lookup instead of O(N) filtering per sell.
+        fifo_indices = defaultdict(int)
 
         for tx in all_txs:
             # Use IST adjustment for dates
@@ -216,20 +219,17 @@ class ScheduleFAService:
 
                 # 2. FIFO Fallback for remaining unlinked quantity
                 if qty_to_sell > 0.000001:
-                    # Sort active lots by buy date
-                    # Optimization: Use pre-grouped lots by asset
                     asset_lots = lots_by_asset.get(tx.asset_id, [])
-                    active_lots = sorted(
-                        [
-                            lot for lot in asset_lots
-                            if lot["current_qty"] > 0
-                        ],
-                        key=lambda x: x["buy_transaction"].transaction_date
-                    )
-
-                    for lot in active_lots:
-                        if qty_to_sell <= 0.000001:
-                            break
+                    # Optimization: Use persistent fifo_index to avoid O(N)
+                    # iteration over already exhausted lots for every sell
+                    while (
+                        fifo_indices[tx.asset_id] < len(asset_lots)
+                        and qty_to_sell > 0.000001
+                    ):
+                        lot = asset_lots[fifo_indices[tx.asset_id]]
+                        if lot["current_qty"] <= 0.000001:
+                            fifo_indices[tx.asset_id] += 1
+                            continue
 
                         take = min(lot["current_qty"], qty_to_sell)
                         lot["current_qty"] -= take
@@ -238,6 +238,9 @@ class ScheduleFAService:
 
                         if start_date <= tx_date_ist <= end_date:
                             lot["gross_proceeds"] += take * tx.price_per_unit
+
+                        if lot["current_qty"] <= 0.000001:
+                            fifo_indices[tx.asset_id] += 1
 
             elif tx.transaction_type in [
                 TransactionType.DIVIDEND,


### PR DESCRIPTION
**💡 What**
Introduced a persistent `fifo_indices` map (`defaultdict(int)`) to track the first unexhausted lot index per asset during the FIFO matching fallback loop in `ScheduleFAService._get_foreign_lots_for_period`. Replaced the $O(N \log N)$ per-sell inner sorting loop with an amortized $O(1)$ `while` loop that advances the pointer index as lots are consumed.

**🎯 Why**
Previously, when matching unlinked sell quantities to historical buy lots, the code fetched the active lots, sorted them sequentially, and iterated through them starting from `index=0` for *every* sell transaction. This led to $O(N^2 \log N)$ complexity, significantly impacting performance and generating a bottleneck when calculating tax schedules for highly active portfolios (like RSUs or heavy trading accounts). The pointer method guarantees each lot is examined at most once per asset, dramatically shifting this loop to $O(N+M)$ amortized time.

**📊 Impact**
Reduces the FIFO lot-matching iteration time from $O(N^2 \log N)$ to $O(N)$, mitigating a massive loop bottleneck for portfolios containing a large history of foreign transactions. This improves overall response times during the `ScheduleFAService` API calls.

**🔬 Measurement**
Verified via local tests (`./run_local_tests.sh backend`) that the business logic behaves exactly identically (all tax accounting flow tests pass successfully) while safely skipping depleted lots using the `0.000001` floating point epsilon check already present in the codebase. Both backend tests and linter passed.

---
*PR created automatically by Jules for task [347360345365934249](https://jules.google.com/task/347360345365934249) started by @aashishbhanawat*