### PR TITLE
🎨 Palette: Improve accessibility of Watchlist Form Modal

### DIFF
--- a/frontend/src/components/modals/WatchlistFormModal.tsx
+++ b/frontend/src/components/modals/WatchlistFormModal.tsx
@@ -34,9 +34,14 @@ const WatchlistFormModal: React.FC<WatchlistFormModalProps> = ({
   if (!isOpen) return null;
 
   return (
-    <div className="modal modal-open">
+    <div
+      className="modal modal-open"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="watchlist-modal-title"
+    >
       <div className="modal-box">
-        <h3 className="font-bold text-lg">
+        <h3 id="watchlist-modal-title" className="font-bold text-lg">
           {isEditMode ? 'Rename Watchlist' : 'Create New Watchlist'}
         </h3>
         <form onSubmit={handleSubmit}>


### PR DESCRIPTION
💡 What: Added ARIA attributes (`role="dialog"`, `aria-modal="true"`, `aria-labelledby`) to the `WatchlistFormModal`.
🎯 Why: To make the "Create New Watchlist" modal accessible to screen readers, aligning it with other modals in the application that properly announce themselves as dialogs when opened.
📸 Before/After: Visuals are exactly the same, but the DOM structure now properly supports accessibility tools.
♿ Accessibility: Ensures the modal operates as a dialog role with `aria-modal` true and an `aria-labelledby` reference linking to the title of the modal, significantly improving keyboard and screen reader navigation context.

---
*PR created automatically by Jules for task [1584711847863850414](https://jules.google.com/task/1584711847863850414) started by @aashishbhanawat*