### PR TITLE
⚡ Bolt: [Optimize PPF asset batch locking]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## YYYY-MM-DD - [Optimize PPF Interest Calculation N+1 Queries]
 **Learning:** In `backend/app/crud/crud_ppf.py`, calculating PPF interest across financial years executed a new database query per month to find historical interest rates (`12` queries per simulated year, `180` queries for 15 years), resulting in massive query amplification during dashboard load.
 **Action:** When performing time-series calculations that rely on historical rates (like PPF interest), always pre-fetch the rates at the beginning of the top-level method (e.g., `process_ppf_holding`) and pass the pre-fetched list to the inner loop functions (e.g., `_calculate_ppf_interest_for_fy`) to do in-memory filtering.
+## 2024-05-18 - [Optimize PPF Asset Batch Locking]
+**Learning:** In `backend/app/crud/crud_holding.py` within `get_all_portfolios_holdings_and_summary`, locking PPF assets individually inside a loop with `.with_for_update().first()` introduces an N+1 database round-trip performance bottleneck, similar to what was previously fixed in `get_portfolio_holdings_and_summary`.
+**Action:** Always batch-lock assets prior to looping over them using an `.in_()` clause when processing multiple entities, avoiding any database queries inside iteration blocks.

--- a/backend/app/crud/crud_holding.py
+++ b/backend/app/crud/crud_holding.py
@@ -1010,6 +1010,15 @@ class CRUDHolding:
         logger.info(f"Found {len(ppf_assets)} PPF assets to process.")
 
         # --- PPF Holdings ---
+        if ppf_assets:
+            # Lock all PPF asset rows at once before processing to prevent race
+            # conditions on the interest calculation logic, which has a write
+            # side-effect. This is only supported by PostgreSQL.
+            ppf_asset_ids = [asset.id for asset in ppf_assets]
+            db.query(models.Asset).filter(
+                models.Asset.id.in_(ppf_asset_ids)
+            ).with_for_update().all()
+
         for ppf_asset in ppf_assets:
             # We don't have a single portfolio id for PPF since we're
             # processing for the whole user.
@@ -1024,8 +1033,6 @@ class CRUDHolding:
             # If None, it processes all transactions for the asset
             # across all portfolios.
 
-            # Lock the asset row before processing
-            db.query(models.Asset).filter_by(id=ppf_asset.id).with_for_update().first()
             logger.info(f"Processing PPF asset {ppf_asset.id}...")
 
             # Call process_ppf_holding with portfolio_id=None to aggregate


### PR DESCRIPTION
💡 **What**: Replaced the per-asset `.with_for_update().first()` locking query inside the `for ppf_asset in ppf_assets:` loop with a single batch `.in_().with_for_update().all()` query outside the loop in `get_all_portfolios_holdings_and_summary`.

🎯 **Why**: The application loaded dashboard data sluggishly due to executing an N+1 query to lock PPF asset rows individually. By batching this query, it avoids multiple unnecessary round-trips to the database, particularly when a user has multiple PPF investments.

📊 **Impact**: Amortizes O(N) database lock queries to O(1), improving multi-portfolio dashboard aggregation response times and reducing database concurrency overhead.

🔬 **Measurement**: Verified using `ruff check` and confirmed through manual code review that the execution logic is equivalent but uses a single batch lock query instead of iterating.

---
*PR created automatically by Jules for task [9626666879191379455](https://jules.google.com/task/9626666879191379455) started by @aashishbhanawat*