### PR TITLE
🎨 Palette: Standardize UsersTable actions with accessible icons

### DIFF
--- a/frontend/src/__tests__/components/Admin/UsersTable.test.tsx
+++ b/frontend/src/__tests__/components/Admin/UsersTable.test.tsx
@@ -30,15 +30,15 @@ describe('UsersTable', () => {
 
   test('calls onEdit with the correct user when Edit button is clicked', () => {
     renderComponent();
-    const editButtons = screen.getAllByRole('button', { name: 'Edit' });
-    fireEvent.click(editButtons[1]); // Click edit for the second user
+    const editButton = screen.getByRole('button', { name: `Edit user ${mockUsers[1].email}` });
+    fireEvent.click(editButton); // Click edit for the second user
     expect(onEdit).toHaveBeenCalledWith(mockUsers[1]);
   });
 
   test('calls onDelete with the correct user when Delete button is clicked', () => {
     renderComponent();
-    const deleteButtons = screen.getAllByRole('button', { name: 'Delete' });
-    fireEvent.click(deleteButtons[0]); // Click delete for the first user
+    const deleteButton = screen.getByRole('button', { name: `Delete user ${mockUsers[0].email}` });
+    fireEvent.click(deleteButton); // Click delete for the first user
     expect(onDelete).toHaveBeenCalledWith(mockUsers[0]);
   });
 });

--- a/frontend/src/components/Admin/UsersTable.tsx
+++ b/frontend/src/components/Admin/UsersTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { User } from '../../types/user';
+import { PencilSquareIcon, TrashIcon } from '@heroicons/react/24/outline';
 
 interface UsersTableProps {
   users: User[];
@@ -27,9 +28,15 @@ const UsersTable: React.FC<UsersTableProps> = ({ users, onEdit, onDelete }) => {
                   {user.is_admin ? 'Admin' : 'User'}
                 </span>
               </td>
-              <td className="text-right py-3 px-4 space-x-2">
-                <button onClick={() => onEdit(user)} className="btn btn-secondary text-sm py-1 px-3">Edit</button>
-                <button onClick={() => onDelete(user)} className="btn btn-danger text-sm py-1 px-3">Delete</button>
+              <td className="text-right py-3 px-4">
+                <div className="flex justify-end items-center space-x-4">
+                  <button onClick={() => onEdit(user)} className="text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 transition-colors" aria-label={`Edit user ${user.email}`} title="Edit User">
+                    <PencilSquareIcon className="h-5 w-5" />
+                  </button>
+                  <button onClick={() => onDelete(user)} className="text-gray-500 hover:text-red-600 dark:hover:text-red-400 transition-colors" aria-label={`Delete user ${user.email}`} title="Delete User">
+                    <TrashIcon className="h-5 w-5" />
+                  </button>
+                </div>
               </td>
             </tr>
           ))}

--- a/frontend/src/components/Admin/UsersTable.tsx
+++ b/frontend/src/components/Admin/UsersTable.tsx
@@ -30,10 +30,10 @@ const UsersTable: React.FC<UsersTableProps> = ({ users, onEdit, onDelete }) => {
               </td>
               <td className="text-right py-3 px-4">
                 <div className="flex justify-end items-center space-x-4">
-                  <button onClick={() => onEdit(user)} className="text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 transition-colors" aria-label={`Edit user ${user.email}`} title="Edit User">
+                  <button type="button" onClick={() => onEdit(user)} className="text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 transition-colors" aria-label={`Edit user ${user.email}`} title="Edit User">
                     <PencilSquareIcon className="h-5 w-5" />
                   </button>
-                  <button onClick={() => onDelete(user)} className="text-gray-500 hover:text-red-600 dark:hover:text-red-400 transition-colors" aria-label={`Delete user ${user.email}`} title="Delete User">
+                  <button type="button" onClick={() => onDelete(user)} className="text-gray-500 hover:text-red-600 dark:hover:text-red-400 transition-colors" aria-label={`Delete user ${user.email}`} title="Delete User">
                     <TrashIcon className="h-5 w-5" />
                   </button>
                 </div>


### PR DESCRIPTION
💡 What: Replaced plain text "Edit" and "Delete" buttons in the UsersTable with standard Heroicons (PencilSquareIcon and TrashIcon) and added descriptive aria-labels.

🎯 Why: To standardize action button styles across application tables (like InterestRateTable and TransactionHistoryTable) reducing visual clutter in dense data grids, while making the interface more pleasant to use.

📸 Before/After: Before, actions were generic "btn btn-secondary Edit" buttons. Now they are minimal, standard inline SVG icons that align well visually.

♿ Accessibility: Added descriptive `aria-label` attributes to the new icon-only buttons (e.g., `Edit user admin@example.com` instead of a generic "Edit"), significantly improving context for screen reader users navigating the table. Updated tests to assert on these new accessible names.

---
*PR created automatically by Jules for task [12744972724977986705](https://jules.google.com/task/12744972724977986705) started by @aashishbhanawat*