### PR TITLE
🎨 Palette: Improved TransactionList empty state and PPF Modal Accessibility

### DIFF
--- a/frontend/src/__tests__/components/Portfolio/TransactionList.test.tsx
+++ b/frontend/src/__tests__/components/Portfolio/TransactionList.test.tsx
@@ -91,6 +91,6 @@ describe('TransactionList', () => {
         <TransactionList transactions={[]} onEdit={mockOnEdit} onDelete={mockOnDelete} />
       </PrivacyProvider>
     );
-    expect(screen.getByText(/no transactions found/i)).toBeInTheDocument();
+    expect(screen.getByText('No transactions')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/Portfolio/PpfHoldingDetailModal.tsx
+++ b/frontend/src/components/Portfolio/PpfHoldingDetailModal.tsx
@@ -177,6 +177,7 @@ const PpfHoldingDetailModal: React.FC<PpfHoldingDetailModalProps> = ({
               </p>
             </div>
             <button
+              aria-label="Close"
               onClick={onClose}
               className="text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:hover:text-gray-200 dark:hover:bg-gray-700 rounded-full w-8 h-8 flex-shrink-0 flex items-center justify-center transition-colors -mt-1 -mr-1"
             >

--- a/frontend/src/components/Portfolio/TransactionList.tsx
+++ b/frontend/src/components/Portfolio/TransactionList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Transaction } from '../../types/portfolio';
 import { usePrivacySensitiveCurrency, formatDate } from '../../utils/formatting';
-import { PencilSquareIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { PencilSquareIcon, TrashIcon, DocumentTextIcon } from '@heroicons/react/24/outline';
 
 interface TransactionListProps {
   transactions: Transaction[];
@@ -15,8 +15,14 @@ const TransactionList: React.FC<TransactionListProps> = ({ transactions, onEdit,
 
   if (!transactions || transactions.length === 0) {
     return (
-      <div className="card text-center p-8">
-        <p className="text-gray-500">No transactions found for this portfolio.</p>
+      <div className="card text-center p-12 bg-gray-50/50 dark:bg-gray-800/50 border border-dashed border-gray-200 dark:border-gray-700">
+        <div className="flex flex-col items-center justify-center space-y-3">
+          <DocumentTextIcon className="h-12 w-12 text-gray-400 dark:text-gray-500" />
+          <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">No transactions</h3>
+          <p className="text-sm text-gray-500 dark:text-gray-400 max-w-sm">
+            There are no transactions recorded for this portfolio yet. Use the "Add Transaction" button above to get started.
+          </p>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
💡 What: Replaced plain text empty state in `TransactionList.tsx` with a styled card including a `DocumentTextIcon`, heading, and actionable description. Also added a missing `aria-label="Close"` to the icon-only close button in `PpfHoldingDetailModal.tsx`.
🎯 Why: To make the empty state more helpful and visually consistent with modern UX patterns, and to ensure screen reader users can navigate and close the PPF modal.
📸 Before/After: Before, it was just text "No transactions found...". Now it's a styled card with an icon.
♿ Accessibility: The `PpfHoldingDetailModal.tsx` close button now has an explicit `aria-label="Close"` for screen readers.

---
*PR created automatically by Jules for task [13284949938639520267](https://jules.google.com/task/13284949938639520267) started by @aashishbhanawat*