### PR TITLE
⚡ Bolt: Memoize chart props to prevent unnecessary renders in Dashboard

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-04-20 - Optimize matching logic in HoldingDetailModal
 **Learning:** Finding items in an array repeatedly within a nested loop creates an $O(N^2)$ bottleneck. Constructing a Map/Dictionary for lookups reduces complexity to $O(N)$.
 **Action:** Always index collections by ID into a Map before performing repeated lookups in a loop.
+## $(date +%Y-%m-%d) - Memoize react-chartjs-2 Props to Prevent Render Churn
+**Learning:** In React applications using `react-chartjs-2`, passing unmemoized object literals directly to the `options` and `data` props of chart components (like `<Pie />` or `<Line />`) causes the underlying Chart.js instances to re-render unnecessarily on every parent component update. This is especially costly when the data object includes dynamic computations, such as mapping over arrays or generating HSL color strings, leading to redundant O(N) operations and significant CPU overhead during rapid UI updates.
+**Action:** Always wrap the `options` and `data` (or `chartData`) object definitions in `useMemo` hooks. For static `options`, use an empty dependency array `[]`. For `chartData`, include the underlying data source (e.g., `[data]`) in the dependency array to ensure the chart only recalculates and updates when the actual data changes.

--- a/frontend/src/components/Dashboard/AssetAllocationChart.tsx
+++ b/frontend/src/components/Dashboard/AssetAllocationChart.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useDashboardAllocation } from '../../hooks/useDashboard';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
 import { Pie } from 'react-chartjs-2';
@@ -20,7 +20,7 @@ const generateColors = (numColors: number) => {
 const AssetAllocationChart: React.FC = () => {
   const { data, isLoading, isError, error } = useDashboardAllocation();
 
-  const options = {
+  const options = useMemo(() => ({
     responsive: true,
     maintainAspectRatio: false,
     plugins: {
@@ -31,9 +31,9 @@ const AssetAllocationChart: React.FC = () => {
         display: false,
       },
     },
-  };
+  }), []);
 
-  const chartData = {
+  const chartData = useMemo(() => ({
     labels: data?.allocation.map((item) => item.ticker) || [],
     datasets: [
       {
@@ -44,7 +44,7 @@ const AssetAllocationChart: React.FC = () => {
         borderWidth: 1,
       },
     ],
-  };
+  }), [data]);
 
   return (
     <div className="card">

--- a/frontend/src/components/Dashboard/PortfolioHistoryChart.tsx
+++ b/frontend/src/components/Dashboard/PortfolioHistoryChart.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { useDashboardHistory } from '../../hooks/useDashboard';
 import {
   Chart as ChartJS,
@@ -33,7 +33,7 @@ const PortfolioHistoryChart: React.FC = () => {
     { value: 'all', label: 'All' },
   ];
 
-  const options = {
+  const options = useMemo(() => ({
     responsive: true,
     maintainAspectRatio: false,
     plugins: {
@@ -44,9 +44,9 @@ const PortfolioHistoryChart: React.FC = () => {
         display: false,
       },
     },
-  };
+  }), []);
 
-  const chartData = {
+  const chartData = useMemo(() => ({
     labels: data?.history.map((point) => point.date) || [],
     datasets: [
       {
@@ -56,7 +56,7 @@ const PortfolioHistoryChart: React.FC = () => {
         backgroundColor: 'rgba(54, 162, 235, 0.5)',
       },
     ],
-  };
+  }), [data]);
 
   return (
     <div className="card">


### PR DESCRIPTION
⚡ Bolt: Memoize chart props to prevent unnecessary renders in Dashboard

💡 What: Wrapped the `options` and `chartData` props in `useMemo` hooks for the `AssetAllocationChart` and `PortfolioHistoryChart` components.
🎯 Why: Passing unmemoized object literals to heavy `react-chartjs-2` components causes them to unnecessarily re-render and re-execute dynamic O(N) calculations (like `map` and HSL color generation) on every parent component update, wasting CPU cycles.
📊 Impact: Eliminates redundant O(N) operations and Chart.js DOM diffing during parent component renders, significantly improving dashboard responsiveness.
🔬 Measurement: Verified via manual inspection, passing linting (`pnpm lint`), unit tests (`pnpm test`), and full E2E Playwright test suite.

---
*PR created automatically by Jules for task [6307231301698215012](https://jules.google.com/task/6307231301698215012) started by @aashishbhanawat*