### PR TITLE
⚡ Bolt: Memoize chart configurations to prevent unnecessary rerenders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-04-20 - Optimize matching logic in HoldingDetailModal
 **Learning:** Finding items in an array repeatedly within a nested loop creates an $O(N^2)$ bottleneck. Constructing a Map/Dictionary for lookups reduces complexity to $O(N)$.
 **Action:** Always index collections by ID into a Map before performing repeated lookups in a loop.
+## 2024-05-25 - React Chartjs-2 Memoization Overhead
+**Learning:** In React components using `react-chartjs-2` (like `AssetAllocationChart` and `PortfolioHistoryChart`), passing unmemoized objects (e.g., `options` or `chartData`) forces expensive internal chart recalculations and triggers redundant O(N) generation logic (like dynamic color mapping) on every parent render.
+**Action:** Always wrap `options` and `data`/`chartData` props in `useMemo` hooks when rendering complex third-party charts to stabilize references and prevent performance degradation.

--- a/frontend/src/components/Dashboard/AssetAllocationChart.tsx
+++ b/frontend/src/components/Dashboard/AssetAllocationChart.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useDashboardAllocation } from '../../hooks/useDashboard';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
 import { Pie } from 'react-chartjs-2';
@@ -20,7 +20,7 @@ const generateColors = (numColors: number) => {
 const AssetAllocationChart: React.FC = () => {
   const { data, isLoading, isError, error } = useDashboardAllocation();
 
-  const options = {
+  const options = useMemo(() => ({
     responsive: true,
     maintainAspectRatio: false,
     plugins: {
@@ -31,9 +31,9 @@ const AssetAllocationChart: React.FC = () => {
         display: false,
       },
     },
-  };
+  }), []);
 
-  const chartData = {
+  const chartData = useMemo(() => ({
     labels: data?.allocation.map((item) => item.ticker) || [],
     datasets: [
       {
@@ -44,7 +44,7 @@ const AssetAllocationChart: React.FC = () => {
         borderWidth: 1,
       },
     ],
-  };
+  }), [data]);
 
   return (
     <div className="card">

--- a/frontend/src/components/Dashboard/PortfolioHistoryChart.tsx
+++ b/frontend/src/components/Dashboard/PortfolioHistoryChart.tsx
@@ -22,16 +22,16 @@ ChartJS.register(
   Legend
 );
 
+const RANGES = [
+  { value: '7d', label: '7D' },
+  { value: '30d', label: '30D' },
+  { value: '1y', label: '1Y' },
+  { value: 'all', label: 'All' },
+];
+
 const PortfolioHistoryChart: React.FC = () => {
   const [range, setRange] = useState('30d');
   const { data, isLoading, isError, error } = useDashboardHistory(range);
-
-  const ranges = useMemo(() => [
-    { value: '7d', label: '7D' },
-    { value: '30d', label: '30D' },
-    { value: '1y', label: '1Y' },
-    { value: 'all', label: 'All' },
-  ], []);
 
   const options = useMemo(() => ({
     responsive: true,
@@ -63,7 +63,7 @@ const PortfolioHistoryChart: React.FC = () => {
       <div className="flex justify-between items-center mb-4">
         <h2 className="text-xl font-semibold dark:text-white">Portfolio History</h2>
         <div className="flex items-center space-x-2">
-          {ranges.map((r) => (
+          {RANGES.map((r) => (
             <button
               key={r.value}
               onClick={() => setRange(r.value)}

--- a/frontend/src/components/Dashboard/PortfolioHistoryChart.tsx
+++ b/frontend/src/components/Dashboard/PortfolioHistoryChart.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { useDashboardHistory } from '../../hooks/useDashboard';
 import {
   Chart as ChartJS,
@@ -26,14 +26,14 @@ const PortfolioHistoryChart: React.FC = () => {
   const [range, setRange] = useState('30d');
   const { data, isLoading, isError, error } = useDashboardHistory(range);
 
-  const ranges = [
+  const ranges = useMemo(() => [
     { value: '7d', label: '7D' },
     { value: '30d', label: '30D' },
     { value: '1y', label: '1Y' },
     { value: 'all', label: 'All' },
-  ];
+  ], []);
 
-  const options = {
+  const options = useMemo(() => ({
     responsive: true,
     maintainAspectRatio: false,
     plugins: {
@@ -44,9 +44,9 @@ const PortfolioHistoryChart: React.FC = () => {
         display: false,
       },
     },
-  };
+  }), []);
 
-  const chartData = {
+  const chartData = useMemo(() => ({
     labels: data?.history.map((point) => point.date) || [],
     datasets: [
       {
@@ -56,7 +56,7 @@ const PortfolioHistoryChart: React.FC = () => {
         backgroundColor: 'rgba(54, 162, 235, 0.5)',
       },
     ],
-  };
+  }), [data]);
 
   return (
     <div className="card">


### PR DESCRIPTION
💡 **What:** Added `useMemo` wrappers to the `options`, `chartData`, and static arrays (like `ranges`) in both `AssetAllocationChart` and `PortfolioHistoryChart`.
🎯 **Why:** By default, creating literal objects and arrays in a React functional component causes them to be recreated with new memory references on every render. For expensive third-party components like `react-chartjs-2`, this change in reference forces unnecessary re-rendering and triggers redundant O(N) calculations (such as dynamic hue color generation or dataset mapping) even when the underlying data hasn't changed.
📊 **Impact:** Prevents re-computation of colors and O(N) mapping, reducing CPU overhead during parent re-renders and improving frontend dashboard responsiveness.
🔬 **Measurement:** Verified via React component tests and strict frontend linting rules. Running React DevTools Profiler will show zero chart update boundaries when parent state (excluding `data`) changes.

---
*PR created automatically by Jules for task [11631826878467426153](https://jules.google.com/task/11631826878467426153) started by @aashishbhanawat*