### PR TITLE
🎨 Palette: Add accessible aria labels to close modal buttons and add aria-hidden on animated spin icons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-25 - Screen Reader Feedback on Loading Buttons and Modals
+**Learning:** `animate-spin` on SVGs without `aria-hidden="true"` can cause screen readers to announce useless graphic elements repeatedly, and modal close buttons using `&times;` (×) are often pronounced as "times" rather than "close" by screen readers if they lack an explicit `aria-label` or clear context. We also observed that when users attempt to dismiss an item from a form, the `×` symbol without label is opaque to screen readers.
+**Action:** Always add `aria-hidden="true"` to decorative spinning loading icons (like `<ArrowPathIcon animate-spin />`). Ensure that icon-only buttons (like `×` or an SVG `XMarkIcon`) use clear `aria-label` attributes like `"Close"` or `"Clear selection"`.

--- a/frontend/src/components/Admin/AssetSyncCard.tsx
+++ b/frontend/src/components/Admin/AssetSyncCard.tsx
@@ -63,7 +63,7 @@ const AssetSyncCard: React.FC = () => {
                     disabled={isLoading}
                     className="btn btn-primary flex items-center disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                    <ArrowPathIcon className={`h-5 w-5 mr-2 ${isLoading ? 'animate-spin' : ''}`} />
+                    <ArrowPathIcon className={`h-5 w-5 mr-2 ${isLoading ? 'animate-spin' : ''}`} aria-hidden="true" />
                     {isLoading ? 'Syncing Assets...' : 'Sync Assets'}
                 </button>
                 <p className="text-xs text-gray-500 dark:text-gray-500 mt-3">

--- a/frontend/src/components/Admin/InterestRateFormModal.tsx
+++ b/frontend/src/components/Admin/InterestRateFormModal.tsx
@@ -98,7 +98,7 @@ const InterestRateFormModal: React.FC<InterestRateFormModalProps> = ({ isOpen, o
                 Cancel
               </button>
               <button type="submit" className="btn btn-primary flex items-center gap-2" disabled={isPending}>
-                {isPending && <ArrowPathIcon className="h-4 w-4 animate-spin" />}
+                {isPending && <ArrowPathIcon className="h-4 w-4 animate-spin" aria-hidden="true" />}
                 {isPending ? 'Saving...' : (isEditing ? 'Save Changes' : 'Create Rate')}
               </button>
             </div>

--- a/frontend/src/components/Admin/UserFormModal.tsx
+++ b/frontend/src/components/Admin/UserFormModal.tsx
@@ -154,7 +154,7 @@ const UserFormModal: React.FC<UserFormModalProps> = ({
                 Cancel
               </button>
               <button type="submit" className="btn btn-primary flex items-center gap-2" disabled={isPending}>
-                {isPending && <ArrowPathIcon className="h-4 w-4 animate-spin" />}
+                {isPending && <ArrowPathIcon className="h-4 w-4 animate-spin" aria-hidden="true" />}
                 {isPending ? 'Saving...' : (isEditing ? 'Save Changes' : 'Create User')}
               </button>
             </div>

--- a/frontend/src/components/Goals/DeleteGoalModal.tsx
+++ b/frontend/src/components/Goals/DeleteGoalModal.tsx
@@ -23,7 +23,11 @@ const DeleteGoalModal: React.FC<DeleteGoalModalProps> = ({ isOpen, onClose, onCo
             >
                 <div className="modal-header">
                     <h2 id="delete-goal-modal-title" className="text-2xl font-bold">Delete Goal</h2>
-                    <button type="button" aria-label="Close" onClick={onClose} className="text-gray-400 hover:text-gray-600">&times;</button>
+                    <button type="button" aria-label="Close" onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6" aria-hidden="true">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+                        </svg>
+                    </button>
                 </div>
                 <div className="p-6">
                     <p id="delete-goal-modal-desc" className="text-gray-600 mb-4">
@@ -36,7 +40,7 @@ const DeleteGoalModal: React.FC<DeleteGoalModalProps> = ({ isOpen, onClose, onCo
                         <button type="button" onClick={onConfirm} className="btn btn-danger flex items-center gap-2" disabled={isPending}>
                             {isPending ? (
                                 <>
-                                    <ArrowPathIcon className="h-4 w-4 animate-spin" />
+                                    <ArrowPathIcon className="h-4 w-4 animate-spin" aria-hidden="true" />
                                     <span>Deleting...</span>
                                 </>
                             ) : (

--- a/frontend/src/components/Portfolio/DeletePortfolioModal.tsx
+++ b/frontend/src/components/Portfolio/DeletePortfolioModal.tsx
@@ -23,7 +23,11 @@ const DeletePortfolioModal: React.FC<DeletePortfolioModalProps> = ({ isOpen, onC
             >
                 <div className="modal-header">
                     <h2 id="delete-modal-title" className="text-2xl font-bold text-red-600 dark:text-red-400">Delete Portfolio</h2>
-                    <button aria-label="Close" onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">&times;</button>
+                    <button aria-label="Close" onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6" aria-hidden="true">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+                        </svg>
+                    </button>
                 </div>
                 <div className="p-6">
                     <p id="delete-modal-desc" className="text-gray-700 dark:text-gray-300 mb-4">
@@ -39,7 +43,7 @@ const DeletePortfolioModal: React.FC<DeletePortfolioModalProps> = ({ isOpen, onC
                         <button type="button" onClick={onConfirm} className="btn btn-danger flex items-center gap-2" disabled={isPending}>
                             {isPending ? (
                                 <>
-                                    <ArrowPathIcon className="h-4 w-4 animate-spin" />
+                                    <ArrowPathIcon className="h-4 w-4 animate-spin" aria-hidden="true" />
                                     <span>Deleting...</span>
                                 </>
                             ) : (

--- a/frontend/src/components/Portfolio/DeletePortfolioModal.tsx
+++ b/frontend/src/components/Portfolio/DeletePortfolioModal.tsx
@@ -23,7 +23,7 @@ const DeletePortfolioModal: React.FC<DeletePortfolioModalProps> = ({ isOpen, onC
             >
                 <div className="modal-header">
                     <h2 id="delete-modal-title" className="text-2xl font-bold text-red-600 dark:text-red-400">Delete Portfolio</h2>
-                    <button aria-label="Close" onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                    <button type="button" aria-label="Close" onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6" aria-hidden="true">
                             <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
                         </svg>

--- a/frontend/src/components/Portfolio/TransactionDetailsModal.tsx
+++ b/frontend/src/components/Portfolio/TransactionDetailsModal.tsx
@@ -20,7 +20,7 @@ const TransactionDetailsModal: React.FC<TransactionDetailsModalProps> = ({ isOpe
             <div className="modal-content w-11/12 max-w-lg p-6 relative" onClick={e => e.stopPropagation()}>
                 <div className="flex justify-between items-center mb-4">
                     <h2 id="transaction-details-modal-title" className="text-xl font-bold">Transaction Details</h2>
-                    <button aria-label="Close" onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                    <button type="button" aria-label="Close" onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6" aria-hidden="true">
                             <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
                         </svg>

--- a/frontend/src/components/Portfolio/TransactionDetailsModal.tsx
+++ b/frontend/src/components/Portfolio/TransactionDetailsModal.tsx
@@ -16,12 +16,16 @@ const TransactionDetailsModal: React.FC<TransactionDetailsModalProps> = ({ isOpe
     const isForeign = transaction.asset.currency !== 'INR';
 
     return (
-        <div className="modal-overlay z-40" onClick={onClose}>
+        <div className="modal-overlay z-40" role="dialog" aria-modal="true" aria-labelledby="transaction-details-modal-title" onClick={onClose}>
             <div className="modal-content w-11/12 max-w-lg p-6 relative" onClick={e => e.stopPropagation()}>
-                <button aria-label="Close" onClick={onClose} className="absolute right-4 top-4 text-gray-500 hover:text-gray-700">
-                    &times;
-                </button>
-                <h2 className="text-xl font-bold mb-4">Transaction Details</h2>
+                <div className="flex justify-between items-center mb-4">
+                    <h2 id="transaction-details-modal-title" className="text-xl font-bold">Transaction Details</h2>
+                    <button aria-label="Close" onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6" aria-hidden="true">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+                        </svg>
+                    </button>
+                </div>
 
                 <div className="space-y-4">
                     <div className="grid grid-cols-2 gap-4 text-sm">

--- a/frontend/src/components/Portfolio/TransactionFormModal.tsx
+++ b/frontend/src/components/Portfolio/TransactionFormModal.tsx
@@ -1559,7 +1559,7 @@ const TransactionFormModal: React.FC<TransactionFormModalProps> = ({ portfolioId
                                                     autoComplete="off"
                                                 />
                                                 {selectedNewAsset && (
-                                                    <button type="button" onClick={handleClearNewAsset} className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600">×</button>
+                                                    <button type="button" onClick={handleClearNewAsset} className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600" aria-label="Clear selection" title="Clear selection">×</button>
                                                 )}
                                             </div>
                                             {isSearchingNewAsset && <p className="text-xs text-gray-500">Searching...</p>}
@@ -1615,7 +1615,7 @@ const TransactionFormModal: React.FC<TransactionFormModalProps> = ({ portfolioId
                                                         autoComplete="off"
                                                     />
                                                     {selectedNewAsset && (
-                                                        <button type="button" onClick={handleClearNewAsset} className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600">×</button>
+                                                        <button type="button" onClick={handleClearNewAsset} className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600" aria-label="Clear selection" title="Clear selection">×</button>
                                                     )}
                                                 </div>
                                                 {isSearchingNewAsset && <p className="text-xs text-gray-500">Searching...</p>}
@@ -1660,7 +1660,7 @@ const TransactionFormModal: React.FC<TransactionFormModalProps> = ({ portfolioId
                                                         autoComplete="off"
                                                     />
                                                     {selectedNewAsset && (
-                                                        <button type="button" onClick={handleClearNewAsset} className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600">×</button>
+                                                        <button type="button" onClick={handleClearNewAsset} className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600" aria-label="Clear selection" title="Clear selection">×</button>
                                                     )}
                                                 </div>
                                                 {isSearchingNewAsset && <p className="text-xs text-gray-500">Searching...</p>}

--- a/frontend/src/components/auth/MobileSeedingSplash.tsx
+++ b/frontend/src/components/auth/MobileSeedingSplash.tsx
@@ -56,7 +56,7 @@ const MobileSeedingSplash: React.FC<MobileSeedingSplashProps> = ({ onComplete })
     if (!statusResponse) {
         return (
             <div className="flex flex-col items-center justify-center p-8 text-center space-y-4">
-                <ArrowPathIcon className="h-12 w-12 text-blue-500 animate-spin mx-auto" />
+                <ArrowPathIcon className="h-12 w-12 text-blue-500 animate-spin mx-auto" aria-hidden="true" />
                 <h2 className="text-xl font-semibold">Connecting to Engine...</h2>
                 <p className="text-gray-500 dark:text-gray-400">Please wait while ArthSaarthi initializes.</p>
                 <button 

--- a/frontend/src/components/common/DeleteConfirmationModal.tsx
+++ b/frontend/src/components/common/DeleteConfirmationModal.tsx
@@ -81,7 +81,7 @@ export const DeleteConfirmationModal: React.FC<
             >
               {isDeleting ? (
                 <>
-                  <ArrowPathIcon className="h-4 w-4 animate-spin" />
+                  <ArrowPathIcon className="h-4 w-4 animate-spin" aria-hidden="true" />
                   <span>Deleting...</span>
                 </>
               ) : (

--- a/frontend/src/components/common/LoadingButton.tsx
+++ b/frontend/src/components/common/LoadingButton.tsx
@@ -21,7 +21,7 @@ const LoadingButton: React.FC<LoadingButtonProps> = ({
       disabled={isLoading || disabled}
       {...props}
     >
-      {isLoading && <ArrowPathIcon className="h-4 w-4 animate-spin" />}
+      {isLoading && <ArrowPathIcon className="h-4 w-4 animate-spin" aria-hidden="true" />}
       {isLoading && loadingText ? loadingText : children}
     </button>
   );

--- a/frontend/src/components/modals/GoalFormModal.tsx
+++ b/frontend/src/components/modals/GoalFormModal.tsx
@@ -122,7 +122,7 @@ const GoalFormModal: React.FC<GoalFormModalProps> = ({
                 className="btn btn-primary flex items-center gap-2"
                 disabled={isPending || !name.trim() || !targetAmount || !targetDate}
               >
-                {isPending && <ArrowPathIcon className="h-4 w-4 animate-spin" />}
+                {isPending && <ArrowPathIcon className="h-4 w-4 animate-spin" aria-hidden="true" />}
                 {isPending ? (isEditMode ? 'Saving...' : 'Creating...') : (isEditMode ? 'Save Changes' : 'Create Goal')}
               </button>
             </div>


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to decorative `animate-spin` `ArrowPathIcon` loaders and replaced raw `&times;` (×) HTML entities with accessible SVG close buttons containing `aria-label`. Added `aria-label="Clear selection"` to inline selection clearance buttons.
🎯 Why: Screen readers often mispronounce `&times;` as "times" rather than indicating a "Close" action. Additionally, repeating SVGs with `animate-spin` are repeatedly read to users if not hidden from ARIA. 
♿ Accessibility: Improved screen reader navigation for forms, modals, and pending operation states.

---
*PR created automatically by Jules for task [15234746660660195660](https://jules.google.com/task/15234746660660195660) started by @aashishbhanawat*