### PR TITLE
🎨 Palette: [UX improvement] Replace &times; with semantic XMarkIcon

### DIFF
--- a/frontend/src/components/Admin/InterestRateFormModal.tsx
+++ b/frontend/src/components/Admin/InterestRateFormModal.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { HistoricalInterestRate, HistoricalInterestRateCreate, HistoricalInterestRateUpdate } from '../../types/interestRate';
 import { useCreateInterestRate, useUpdateInterestRate } from '../../hooks/useInterestRates';
-import { ArrowPathIcon } from '@heroicons/react/24/outline';
+import { ArrowPathIcon, XMarkIcon } from '@heroicons/react/24/outline';
 
 interface InterestRateFormModalProps {
   isOpen: boolean;
@@ -61,7 +61,9 @@ const InterestRateFormModal: React.FC<InterestRateFormModalProps> = ({ isOpen, o
       <div role="dialog" aria-modal="true" aria-labelledby="rate-form-modal-title" className="modal-content max-w-md">
         <div className="modal-header">
           <h2 id="rate-form-modal-title" className="text-2xl font-bold">{isEditing ? 'Edit Interest Rate' : 'Add New Interest Rate'}</h2>
-          <button aria-label="Close" onClick={onClose} className="text-gray-400 hover:text-gray-600">&times;</button>
+          <button aria-label="Close" onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+          </button>
         </div>
         <div className="p-6">
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/frontend/src/components/Admin/UserFormModal.tsx
+++ b/frontend/src/components/Admin/UserFormModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { User, UserUpdate } from '../../types/user';
 import { useCreateUser, useUpdateUser } from '../../hooks/useUsers';
-import { ArrowPathIcon } from '@heroicons/react/24/outline';
+import { ArrowPathIcon, XMarkIcon } from '@heroicons/react/24/outline';
 
 interface UserFormModalProps {
   isOpen: boolean;
@@ -94,7 +94,9 @@ const UserFormModal: React.FC<UserFormModalProps> = ({
       <div role="dialog" aria-modal="true" aria-labelledby="user-form-modal-title" className="modal-content max-w-md">
         <div className="modal-header">
           <h2 id="user-form-modal-title" className="text-2xl font-bold">{isEditing ? 'Edit User' : 'Create New User'}</h2>
-          <button aria-label="Close" onClick={onClose} className="text-gray-400 hover:text-gray-600">&times;</button>
+          <button aria-label="Close" onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+          </button>
         </div>
         <div className="p-6">
           <form onSubmit={handleSubmit}>

--- a/frontend/src/components/Portfolio/AddAwardModal.tsx
+++ b/frontend/src/components/Portfolio/AddAwardModal.tsx
@@ -8,6 +8,7 @@ import { useDebounce } from '../../hooks/useDebounce';
 import { Asset } from '../../types/asset';
 import { Transaction, TransactionCreate, TransactionUpdate } from '../../types/portfolio';
 import { TransactionType } from '../../types/enums';
+import { XMarkIcon } from '@heroicons/react/24/outline';
 
 interface AddAwardModalProps {
     portfolioId: string;
@@ -245,7 +246,9 @@ const AddAwardModal: React.FC<AddAwardModalProps> = ({ portfolioId, onClose, isO
             <div role="dialog" className="modal-content w-11/12 md:w-3/4 lg:max-w-2xl p-6 overflow-visible" onClick={e => e.stopPropagation()}>
                 <div className="flex justify-between items-center mb-4">
                     <h2 className="text-2xl font-bold">{isEditMode ? 'Edit' : 'Add'} ESPP/RSU Award</h2>
-                    <button aria-label="Close" onClick={onClose} className="text-gray-500 hover:text-gray-700 text-2xl">&times;</button>
+                    <button aria-label="Close" onClick={onClose} className="text-gray-500 hover:text-gray-700">
+                        <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                    </button>
                 </div>
 
                 <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
@@ -292,10 +295,11 @@ const AddAwardModal: React.FC<AddAwardModalProps> = ({ portfolioId, onClose, isO
                             {selectedAsset && (
                                 <button
                                     type="button"
+                                    aria-label="Clear selection"
                                     onClick={handleClearAsset}
                                     className="absolute right-2 top-2 text-red-500 font-bold"
                                 >
-                                    &times;
+                                    <XMarkIcon className="h-5 w-5" aria-hidden="true" />
                                 </button>
                             )}
                         </div>

--- a/frontend/src/components/Portfolio/PpfHoldingDetailModal.tsx
+++ b/frontend/src/components/Portfolio/PpfHoldingDetailModal.tsx
@@ -1,4 +1,4 @@
-import { PencilSquareIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { PencilSquareIcon, TrashIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import React from 'react';
 
 import { useAssetAnalytics, useAssetTransactions } from '../../hooks/usePortfolios';
@@ -181,8 +181,9 @@ const PpfHoldingDetailModal: React.FC<PpfHoldingDetailModalProps> = ({
           <button
             onClick={onClose}
             className="text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:hover:text-gray-200 dark:hover:bg-gray-700 rounded-full w-8 h-8 flex items-center justify-center transition-colors -mr-2 -mt-2"
+            aria-label="Close"
           >
-            <span className="text-2xl leading-none">&times;</span>
+            <XMarkIcon className="h-6 w-6" aria-hidden="true" />
           </button>
         </div>
         {renderContent()}

--- a/frontend/src/components/Portfolio/TransactionFormModal.tsx
+++ b/frontend/src/components/Portfolio/TransactionFormModal.tsx
@@ -16,6 +16,7 @@ import { ApiError, getErrorMessage } from '../../types/api';
 import Select from 'react-select';
 import { formatCurrency } from '../../utils/formatting';
 import { debugLog } from '../../utils/debug';
+import { XMarkIcon } from '@heroicons/react/24/outline';
 
 interface TransactionFormModalProps {
     portfolioId: string;
@@ -956,8 +957,8 @@ const TransactionFormModal: React.FC<TransactionFormModalProps> = ({ portfolioId
                                                 {!isEditMode && (
                                                     <>
                                                         {selectedAsset && (
-                                                            <button type="button" onClick={handleClearSelectedAsset} className="absolute right-2 top-2 text-red-500 text-xl font-bold">
-                                                                &times;
+                                                            <button type="button" aria-label="Clear selection" onClick={handleClearSelectedAsset} className="absolute right-2 top-2 text-red-500 font-bold">
+                                                                <XMarkIcon className="h-5 w-5" aria-hidden="true" />
                                                             </button>
                                                         )}
                                                         {isSearching && <div className="absolute z-20 w-full bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md mt-1 p-2 shadow-lg dark:text-gray-200">Searching...</div>}
@@ -1074,9 +1075,8 @@ const TransactionFormModal: React.FC<TransactionFormModalProps> = ({ portfolioId
                                                 {!isEditMode && (
                                                     <>
                                                         {selectedAsset && (
-                                                            <button type="button" onClick={handleClearSelectedAsset} className="absolute right-2 top-2 text-red-500 text-xl font-bold">
-
-                                                                &times;
+                                                            <button type="button" aria-label="Clear selection" onClick={handleClearSelectedAsset} className="absolute right-2 top-2 text-red-500 font-bold">
+                                                                <XMarkIcon className="h-5 w-5" aria-hidden="true" />
                                                             </button>
                                                         )}
                                                         {isSearching && <div className="absolute z-20 w-full bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md mt-1 p-2 shadow-lg dark:text-gray-200">Searching...</div>}

--- a/frontend/src/components/modals/AssetLinkModal.tsx
+++ b/frontend/src/components/modals/AssetLinkModal.tsx
@@ -5,6 +5,7 @@ import { useDebounce } from '../../hooks/useDebounce';
 import { Goal } from '../../types/goal';
 import { Portfolio } from '../../types/portfolio';
 import { AssetSearchResult } from '../../types/asset';
+import { XMarkIcon } from '@heroicons/react/24/outline';
 
 interface AssetLinkModalProps {
     isOpen: boolean;
@@ -41,7 +42,9 @@ const AssetLinkModal: React.FC<AssetLinkModalProps> = ({ isOpen, onClose, onLink
             <div className="modal-content w-full max-w-lg overflow-visible flex flex-col h-[32rem]"> {/* Set a height and flex layout */}
                 <div className="modal-header">
                     <h2 className="text-2xl font-bold">Link Item to "{goal.name}"</h2>
-                    <button aria-label="Close" onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">&times;</button>
+                    <button aria-label="Close" onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+                        <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                    </button>
                 </div>
                 <div className="p-6 flex flex-col flex-grow">
                     <div className="form-group relative">

--- a/frontend/src/components/modals/GoalFormModal.tsx
+++ b/frontend/src/components/modals/GoalFormModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Goal, GoalCreate, GoalUpdate } from '../../types/goal';
-import { ArrowPathIcon } from '@heroicons/react/24/outline';
+import { ArrowPathIcon, XMarkIcon } from '@heroicons/react/24/outline';
 
 interface GoalFormModalProps {
   isOpen: boolean;
@@ -59,7 +59,9 @@ const GoalFormModal: React.FC<GoalFormModalProps> = ({
           <h2 id="goal-modal-title" className="text-2xl font-bold">
             {isEditMode ? 'Edit Goal' : 'Create New Goal'}
           </h2>
-          <button aria-label="Close" onClick={onClose} className="text-gray-400 hover:text-gray-600">&times;</button>
+          <button aria-label="Close" onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+          </button>
         </div>
         <div className="p-6">
           <form onSubmit={handleSubmit}>


### PR DESCRIPTION
💡 What: Replaced the HTML entity `&times;` (`×`) with the semantic `@heroicons` `XMarkIcon` component combined with `aria-hidden="true"` and appropriate `aria-label`s on their parent buttons across multiple modal components.
🎯 Why: Screen readers frequently mispronounce the HTML entity `&times;` (`×`) as "times", causing a confusing experience for users navigating with assistive technologies. Using a standard, hidden SVG with an `aria-label` provides the correct semantic meaning and an improved user experience.
📸 Before/After: Modals previously displayed a large, potentially misaligned `×` text character. They now display a consistently sized and aligned SVG 'X' icon matching the rest of the application's design system.
♿ Accessibility: Added descriptive `aria-label="Close"` and `aria-label="Clear selection"` to the parent `<button>` elements that were missing them. Applied `aria-hidden="true"` to the decorative `<XMarkIcon>` SVGs to prevent redundant screen reader announcements.

---
*PR created automatically by Jules for task [1277029846539484104](https://jules.google.com/task/1277029846539484104) started by @aashishbhanawat*