### PR TITLE
fix(transactions): restrict update and delete on system-generated PPF interest credit transactions

### DIFF
--- a/backend/app/api/v1/endpoints/transactions.py
+++ b/backend/app/api/v1/endpoints/transactions.py
@@ -345,6 +345,15 @@ def update_transaction(
     if transaction.user_id != current_user.id:
         raise HTTPException(status_code=403, detail="Not enough permissions")
 
+    if (
+        transaction.asset.asset_type == "PPF"
+        and transaction.transaction_type == TransactionType.INTEREST_CREDIT.value
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="PPF interest credit transactions are system-generated and cannot be modified.",
+        )
+
     # --- Smart Recalculation for PPF ---
     if transaction.asset.asset_type == "PPF":
         logger.info(f"Triggering PPF recalculation for asset {transaction.asset_id} "
@@ -389,6 +398,15 @@ def delete_transaction(
         )
     if transaction.user_id != current_user.id:
         raise HTTPException(status_code=403, detail="Not enough permissions")
+
+    if (
+        transaction.asset.asset_type == "PPF"
+        and transaction.transaction_type == TransactionType.INTEREST_CREDIT.value
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="PPF interest credit transactions are system-generated and cannot be deleted.",
+        )
 
     # --- Smart Recalculation for PPF ---
     if transaction.asset.asset_type == "PPF":

--- a/backend/app/api/v1/endpoints/transactions.py
+++ b/backend/app/api/v1/endpoints/transactions.py
@@ -346,16 +346,20 @@ def update_transaction(
         raise HTTPException(status_code=403, detail="Not enough permissions")
 
     if (
-        transaction.asset.asset_type == "PPF"
+        transaction.asset
+        and transaction.asset.asset_type == "PPF"
         and transaction.transaction_type == TransactionType.INTEREST_CREDIT.value
     ):
         raise HTTPException(
             status_code=400,
-            detail="PPF interest credit transactions are system-generated and cannot be modified.",
+            detail=(
+                "PPF interest credit transactions are system-generated "
+                "and cannot be modified."
+            ),
         )
 
     # --- Smart Recalculation for PPF ---
-    if transaction.asset.asset_type == "PPF":
+    if transaction.asset and transaction.asset.asset_type == "PPF":
         logger.info(f"Triggering PPF recalculation for asset {transaction.asset_id} "
                     f"due to transaction update."
         )
@@ -400,16 +404,20 @@ def delete_transaction(
         raise HTTPException(status_code=403, detail="Not enough permissions")
 
     if (
-        transaction.asset.asset_type == "PPF"
+        transaction.asset
+        and transaction.asset.asset_type == "PPF"
         and transaction.transaction_type == TransactionType.INTEREST_CREDIT.value
     ):
         raise HTTPException(
             status_code=400,
-            detail="PPF interest credit transactions are system-generated and cannot be deleted.",
+            detail=(
+                "PPF interest credit transactions are system-generated "
+                "and cannot be deleted."
+            ),
         )
 
     # --- Smart Recalculation for PPF ---
-    if transaction.asset.asset_type == "PPF":
+    if transaction.asset and transaction.asset.asset_type == "PPF":
         logger.info(f"Triggering PPF recalculation for asset {transaction.asset_id} "
                     f"due to transaction deletion."
         )

--- a/backend/app/tests/api/v1/test_portfolios_transactions.py
+++ b/backend/app/tests/api/v1/test_portfolios_transactions.py
@@ -294,3 +294,57 @@ def test_delete_transaction(client: TestClient, db: Session, get_auth_headers):
     assert response.json()["msg"] == "Transaction deleted successfully"
     db_transaction = crud.transaction.get(db, id=transaction_id)
     assert db_transaction is None
+
+
+def test_ppf_interest_credit_immutability(
+    client: TestClient, db: Session, get_auth_headers
+) -> None:
+    from app import schemas
+
+    user, password = create_random_user(db)
+    headers = get_auth_headers(user.email, password)
+    portfolio = create_test_portfolio(db, user_id=user.id, name="PPF Portfolio")
+
+    # Create a PPF asset
+    asset_in = schemas.AssetCreate(
+        name="Test PPF Asset",
+        ticker_symbol="TEST_PPF",
+        asset_type="PPF",
+        currency="INR",
+        exchange="N/A",
+    )
+    asset = crud.asset.create(db=db, obj_in=asset_in)
+
+    # Create an INTEREST_CREDIT transaction
+    transaction = create_test_transaction(
+        db,
+        portfolio_id=portfolio.id,
+        asset_id=asset.id,
+        quantity=5000,
+        price_per_unit=1.0,
+        transaction_type="INTEREST_CREDIT",
+    )
+    transaction_id = transaction.id
+
+    # 1. Verify updating the transaction returns 400
+    update_data = {"quantity": 6000.0}
+    response = client.put(
+        f"{settings.API_V1_STR}/transactions/{transaction_id}?portfolio_id={portfolio.id}",
+        headers=headers,
+        json=update_data,
+    )
+    assert response.status_code == 400
+    assert "cannot be modified" in response.json()["detail"]
+
+    # 2. Verify deleting the transaction returns 400
+    response = client.delete(
+        f"{settings.API_V1_STR}/transactions/{transaction_id}?portfolio_id={portfolio.id}",
+        headers=headers,
+    )
+    assert response.status_code == 400
+    assert "cannot be deleted" in response.json()["detail"]
+
+    # Verify transaction still exists in db
+    db_transaction = crud.transaction.get(db, id=transaction_id)
+    assert db_transaction is not None
+

--- a/docs/project_handoff_summary.md
+++ b/docs/project_handoff_summary.md
@@ -1,6 +1,6 @@
 # Project Handoff & Status Summary
 
-**Last Updated:** 2026-06-04
+**Last Updated:** 2026-06-07
 
 ## 1. Current Project Status
 
@@ -12,16 +12,17 @@
 
 *   **Backend Unit/Integration Tests (Postgres/Redis):** ✅ **327/327 Passing**
 *   **Backend Integration Tests (Android/SQLite):** ✅ **324/327 Passing** (3 expected skips)
-*   **Frontend Unit Tests (Jest):** ✅ **58/58 Passing** (Resolved responsive layout conflicts)
+*   **Frontend Unit Tests (Jest):** ✅ **188/188 Passing** (Extracted shared transaction utilities)
 *   **E2E Playwright Tests (Import/Timeout):** ✅ **5/5 Passing**
 *   **Frontend TypeScript Compilation:** ✅ **Zero Errors**
 *   **Linters (Code Quality):** ✅ **Passing (0 Errors)**
 
 ### Recent Stabilization & Refinement Efforts
 
-*   **PPF Interest Transaction Security (Issue #440) (2026-06-04):**
-    - **Backend Protection:** Implemented checks in `PUT /api/v1/transactions/{transaction_id}` and `DELETE /api/v1/transactions/{transaction_id}` endpoints to reject updates or deletions of `INTEREST_CREDIT` transactions belonging to a `PPF` asset, returning a `400 Bad Request` HTTP error.
+*   **PPF Interest Transaction Security (Issue #440) (Updated 2026-06-07):**
+    - **Backend Protection:** Implemented checks in `PUT /api/v1/transactions/{transaction_id}` and `DELETE /api/v1/transactions/{transaction_id}` endpoints to reject updates or deletions of `INTEREST_CREDIT` transactions belonging to a `PPF` asset, returning a `400 Bad Request` HTTP error. Added defensive checks to ensure `transaction.asset` is not `None` before checking `asset_type`.
     - **Frontend Immutability:** Disabled the "Edit" and "Delete" buttons in the desktop `TransactionHistoryTable` and portfolio `TransactionList` views with explanatory tooltip titles. Hid the edit/delete options entirely in the mobile card-based `TransactionCard` view.
+    - **DRY Refactoring:** Extracted the transaction helper functions (`isEditable`, `isDeletable`, `getDisabledTitle`) into a shared utility file (`frontend/src/utils/transaction.ts`) to avoid duplicate logic across frontend components.
     - **Verification:** Added `test_ppf_interest_credit_immutability` to the integration test suite, verifying both update and delete operations are rejected. Passed all backend and frontend unit tests cleanly.
 
 *   **Asset Seeding & Classification Bug (2026-06-04):**

--- a/docs/project_handoff_summary.md
+++ b/docs/project_handoff_summary.md
@@ -6,18 +6,23 @@
 
 *   **Overall Status:** Ready for PR / Release Candidate
 
-**Latest Achievement:** Resolved regular stock misclassification as bonds (Issue #438) by implementing an in-memory NSEScripMaster ISIN-to-Series mapping, data sanitization (whitespace/quote stripping), and refined regex month heuristics.
+**Latest Achievement:** Secured PPF interest credit transactions by preventing updates and deletions in the backend API and disabling/hiding corresponding action buttons in the frontend UI (Issue #440).
 
 ## 2. Test Suite Status
 
-*   **Backend Unit/Integration Tests (Postgres/Redis):** ✅ **326/326 Passing**
-*   **Backend Integration Tests (Android/SQLite):** ✅ **323/326 Passing** (3 expected skips)
+*   **Backend Unit/Integration Tests (Postgres/Redis):** ✅ **327/327 Passing**
+*   **Backend Integration Tests (Android/SQLite):** ✅ **324/327 Passing** (3 expected skips)
 *   **Frontend Unit Tests (Jest):** ✅ **58/58 Passing** (Resolved responsive layout conflicts)
 *   **E2E Playwright Tests (Import/Timeout):** ✅ **5/5 Passing**
 *   **Frontend TypeScript Compilation:** ✅ **Zero Errors**
 *   **Linters (Code Quality):** ✅ **Passing (0 Errors)**
 
 ### Recent Stabilization & Refinement Efforts
+
+*   **PPF Interest Transaction Security (Issue #440) (2026-06-04):**
+    - **Backend Protection:** Implemented checks in `PUT /api/v1/transactions/{transaction_id}` and `DELETE /api/v1/transactions/{transaction_id}` endpoints to reject updates or deletions of `INTEREST_CREDIT` transactions belonging to a `PPF` asset, returning a `400 Bad Request` HTTP error.
+    - **Frontend Immutability:** Disabled the "Edit" and "Delete" buttons in the desktop `TransactionHistoryTable` and portfolio `TransactionList` views with explanatory tooltip titles. Hid the edit/delete options entirely in the mobile card-based `TransactionCard` view.
+    - **Verification:** Added `test_ppf_interest_credit_immutability` to the integration test suite, verifying both update and delete operations are rejected. Passed all backend and frontend unit tests cleanly.
 
 *   **Asset Seeding & Classification Bug (2026-06-04):**
     - **Asset Misclassification Fix:** Resolved Git Issue #438 where regular stocks containing month-like substrings in their names (e.g., "Indraprastha Gas" containing "APR", "Amara Raja" containing "MAR") were incorrectly classified as `BOND`.

--- a/docs/workflow_history.md
+++ b/docs/workflow_history.md
@@ -1,3 +1,24 @@
+## 2026-06-04: Securing PPF Interest Transactions (Issue #440)
+
+**Task:** Prevent unauthorized editing or deletion of system-generated PPF interest credit transactions by enforcing read-only status in the backend and disabling action buttons in the frontend UI.
+
+**AI Assistant:** Antigravity
+**Role:** Full-Stack Developer
+
+### Summary
+
+Successfully implemented restrictions to prevent updating or deleting system-generated PPF interest credit transactions, securing data integrity.
+
+1. **Backend Protection:** Updated `backend/app/api/v1/endpoints/transactions.py` to intercept `PUT` and `DELETE` requests for transactions that belong to a `PPF` asset and are of type `INTEREST_CREDIT`, returning a `400 Bad Request` HTTP error.
+2. **Backend Integration Tests:** Appended a new integration test `test_ppf_interest_credit_immutability` to `backend/app/tests/api/v1/test_portfolios_transactions.py` verifying that unauthorized modification and deletion requests are rejected with a 400 error.
+3. **Frontend UI Restrictions:**
+   - **TransactionHistoryTable.tsx:** Disabled "Edit" and "Delete" buttons in the desktop view for PPF interest credit rows, adding explanatory tooltip titles.
+   - **TransactionCard.tsx:** Hid "Edit" and "Delete" buttons entirely in the mobile view cards for interest credit rows.
+   - **TransactionList.tsx:** Disabled "Edit" and "Delete" icon buttons in the portfolio transaction list table for interest credit rows with a tooltip explanation.
+4. **Verification:** Ran full backend pytest and frontend Jest test suites. All 188 frontend unit tests and backend transaction tests passed successfully.
+
+---
+
 ## 2026-06-04: Resolve Asset Seeding Bond Misclassification (Issue #438)
 
 **Task:** Fix incorrect classification of regular equities (e.g. Indraprastha Gas, Amara Raja) as bonds by using an in-memory NSEScripMaster ISIN-to-Series mapping and a refined month regex heuristic.

--- a/docs/workflow_history.md
+++ b/docs/workflow_history.md
@@ -15,7 +15,10 @@ Successfully implemented restrictions to prevent updating or deleting system-gen
    - **TransactionHistoryTable.tsx:** Disabled "Edit" and "Delete" buttons in the desktop view for PPF interest credit rows, adding explanatory tooltip titles.
    - **TransactionCard.tsx:** Hid "Edit" and "Delete" buttons entirely in the mobile view cards for interest credit rows.
    - **TransactionList.tsx:** Disabled "Edit" and "Delete" icon buttons in the portfolio transaction list table for interest credit rows with a tooltip explanation.
-4. **Verification:** Ran full backend pytest and frontend Jest test suites. All 188 frontend unit tests and backend transaction tests passed successfully.
+4. **PR Review Enhancements (2026-06-07):**
+   - **Defensive Backend Checking:** Added defensive checks in `update_transaction` and `delete_transaction` to ensure `transaction.asset` is not `None` before checking `asset_type`, preventing potential `AttributeError` crashes.
+   - **Frontend DRY Extraction:** Extracted identical transaction helper functions (`isEditable`, `isDeletable`, `getDisabledTitle`) into a shared utility file `frontend/src/utils/transaction.ts` and imported them in `TransactionHistoryTable.tsx`, `TransactionCard.tsx`, and `TransactionList.tsx`.
+5. **Verification:** Ran backend pytest suite (SQLite mode) and frontend Jest unit tests (188/188 passing).
 
 ---
 

--- a/frontend/src/components/Portfolio/TransactionList.tsx
+++ b/frontend/src/components/Portfolio/TransactionList.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Transaction } from '../../types/portfolio';
 import { usePrivacySensitiveCurrency, formatDate } from '../../utils/formatting';
+import { isEditable, isDeletable, getDisabledTitle } from '../../utils/transaction';
 import { PencilSquareIcon, TrashIcon } from '@heroicons/react/24/outline';
 
 interface TransactionListProps {
@@ -9,40 +10,6 @@ interface TransactionListProps {
   onEdit: (transaction: Transaction) => void;
   onDelete: (transaction: Transaction) => void;
 }
-
-const isEditable = (tx: Transaction): boolean => {
-  if (tx.details && (tx.details as Record<string, unknown>)._fd_id) {
-    return false;
-  }
-  if (tx.asset.asset_type === 'PPF' && tx.transaction_type === 'INTEREST_CREDIT') {
-    return false;
-  }
-  return true;
-};
-
-const isDeletable = (tx: Transaction): boolean => {
-  if (tx.asset.asset_type === 'PPF' && tx.transaction_type === 'INTEREST_CREDIT') {
-    return false;
-  }
-  if (tx.details && (tx.details as Record<string, unknown>)._fd_id) {
-    return tx.transaction_type === 'FD_MATURITY';
-  }
-  return true;
-};
-
-const getDisabledTitle = (tx: Transaction, action: 'edit' | 'delete'): string | undefined => {
-  if (tx.asset.asset_type === 'PPF' && tx.transaction_type === 'INTEREST_CREDIT') {
-    return `PPF interest credit transactions are system-generated and cannot be ${action === 'edit' ? 'modified' : 'deleted'}.`;
-  }
-  if (tx.details && (tx.details as Record<string, unknown>)._fd_id) {
-    if (action === 'edit') {
-      return 'Fixed Deposit transactions are system-generated and cannot be modified.';
-    } else if (tx.transaction_type !== 'FD_MATURITY') {
-      return 'Fixed Deposit transactions are system-generated and cannot be deleted.';
-    }
-  }
-  return undefined;
-};
 
 const TransactionList: React.FC<TransactionListProps> = ({ transactions, onEdit, onDelete }) => {
   const formatCurrency = usePrivacySensitiveCurrency();

--- a/frontend/src/components/Portfolio/TransactionList.tsx
+++ b/frontend/src/components/Portfolio/TransactionList.tsx
@@ -10,6 +10,40 @@ interface TransactionListProps {
   onDelete: (transaction: Transaction) => void;
 }
 
+const isEditable = (tx: Transaction): boolean => {
+  if (tx.details && (tx.details as Record<string, unknown>)._fd_id) {
+    return false;
+  }
+  if (tx.asset.asset_type === 'PPF' && tx.transaction_type === 'INTEREST_CREDIT') {
+    return false;
+  }
+  return true;
+};
+
+const isDeletable = (tx: Transaction): boolean => {
+  if (tx.asset.asset_type === 'PPF' && tx.transaction_type === 'INTEREST_CREDIT') {
+    return false;
+  }
+  if (tx.details && (tx.details as Record<string, unknown>)._fd_id) {
+    return tx.transaction_type === 'FD_MATURITY';
+  }
+  return true;
+};
+
+const getDisabledTitle = (tx: Transaction, action: 'edit' | 'delete'): string | undefined => {
+  if (tx.asset.asset_type === 'PPF' && tx.transaction_type === 'INTEREST_CREDIT') {
+    return `PPF interest credit transactions are system-generated and cannot be ${action === 'edit' ? 'modified' : 'deleted'}.`;
+  }
+  if (tx.details && (tx.details as Record<string, unknown>)._fd_id) {
+    if (action === 'edit') {
+      return 'Fixed Deposit transactions are system-generated and cannot be modified.';
+    } else if (tx.transaction_type !== 'FD_MATURITY') {
+      return 'Fixed Deposit transactions are system-generated and cannot be deleted.';
+    }
+  }
+  return undefined;
+};
+
 const TransactionList: React.FC<TransactionListProps> = ({ transactions, onEdit, onDelete }) => {
   const formatCurrency = usePrivacySensitiveCurrency();
 
@@ -76,8 +110,24 @@ const TransactionList: React.FC<TransactionListProps> = ({ transactions, onEdit,
                 )}</td>
                 <td className="p-3 text-center">
                   <div className="flex justify-center space-x-2">
-                    <button onClick={() => onEdit(tx)} className="p-1 text-gray-500 hover:text-blue-600" aria-label={`Edit transaction for ${tx.asset.ticker_symbol}`}><PencilSquareIcon className="h-5 w-5" /></button>
-                    <button onClick={() => onDelete(tx)} className="p-1 text-gray-500 hover:text-red-600" aria-label={`Delete transaction for ${tx.asset.ticker_symbol}`}><TrashIcon className="h-5 w-5" /></button>
+                    <button
+                      onClick={() => onEdit(tx)}
+                      className="p-1 text-gray-500 hover:text-blue-600 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-gray-500"
+                      disabled={!isEditable(tx)}
+                      title={getDisabledTitle(tx, 'edit')}
+                      aria-label={`Edit transaction for ${tx.asset.ticker_symbol}`}
+                    >
+                      <PencilSquareIcon className="h-5 w-5" />
+                    </button>
+                    <button
+                      onClick={() => onDelete(tx)}
+                      className="p-1 text-gray-500 hover:text-red-600 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-gray-500"
+                      disabled={!isDeletable(tx)}
+                      title={getDisabledTitle(tx, 'delete')}
+                      aria-label={`Delete transaction for ${tx.asset.ticker_symbol}`}
+                    >
+                      <TrashIcon className="h-5 w-5" />
+                    </button>
                   </div>
                 </td>
               </tr>

--- a/frontend/src/components/Transactions/TransactionCard.tsx
+++ b/frontend/src/components/Transactions/TransactionCard.tsx
@@ -39,8 +39,19 @@ const hasUserVisibleDetails = (details: Record<string, unknown> | null | undefin
     return Object.keys(details).some(k => !internalKeys.has(k));
 };
 
-const isSyntheticFd = (tx: Transaction): boolean =>
-    !!(tx.details as Record<string, unknown> | null)?._fd_id;
+const isEditable = (tx: Transaction): boolean => {
+    if (tx.details && (tx.details as Record<string, unknown>)._fd_id) return false;
+    if (tx.asset.asset_type === 'PPF' && tx.transaction_type === 'INTEREST_CREDIT') return false;
+    return true;
+};
+
+const isDeletable = (tx: Transaction): boolean => {
+    if (tx.asset.asset_type === 'PPF' && tx.transaction_type === 'INTEREST_CREDIT') return false;
+    if (tx.details && (tx.details as Record<string, unknown>)._fd_id) {
+        return tx.transaction_type === 'FD_MATURITY';
+    }
+    return true;
+};
 
 const TransactionCard: React.FC<TransactionCardProps> = ({ transaction: tx, onEdit, onDelete, onViewDetails }) => {
     const formatCurrency = usePrivacySensitiveCurrency();
@@ -87,7 +98,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({ transaction: tx, onEd
 
             <div className="pt-3 border-t border-gray-50 dark:border-gray-700 flex justify-between items-center">
                 <div className="flex items-center gap-1">
-                    {!isSyntheticFd(tx) && (
+                    {isEditable(tx) && (
                         <button
                             onClick={() => onEdit(tx)}
                             className="p-2 text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
@@ -96,7 +107,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({ transaction: tx, onEd
                             <PencilIcon className="h-5 w-5" />
                         </button>
                     )}
-                    {(!isSyntheticFd(tx) || tx.transaction_type === 'FD_MATURITY') && (
+                    {isDeletable(tx) && (
                         <button
                             onClick={() => onDelete(tx)}
                             className="p-2 text-gray-500 hover:text-red-600 dark:hover:text-red-400 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"

--- a/frontend/src/components/Transactions/TransactionCard.tsx
+++ b/frontend/src/components/Transactions/TransactionCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Transaction } from '../../types/portfolio';
 import { usePrivacySensitiveCurrency, formatDate } from '../../utils/formatting';
+import { isEditable, isDeletable } from '../../utils/transaction';
 import { InformationCircleIcon, PencilIcon, TrashIcon } from '@heroicons/react/24/outline';
 
 interface TransactionCardProps {
@@ -37,20 +38,6 @@ const hasUserVisibleDetails = (details: Record<string, unknown> | null | undefin
     if (!details) return false;
     const internalKeys = new Set(['_fd_id']);
     return Object.keys(details).some(k => !internalKeys.has(k));
-};
-
-const isEditable = (tx: Transaction): boolean => {
-    if (tx.details && (tx.details as Record<string, unknown>)._fd_id) return false;
-    if (tx.asset.asset_type === 'PPF' && tx.transaction_type === 'INTEREST_CREDIT') return false;
-    return true;
-};
-
-const isDeletable = (tx: Transaction): boolean => {
-    if (tx.asset.asset_type === 'PPF' && tx.transaction_type === 'INTEREST_CREDIT') return false;
-    if (tx.details && (tx.details as Record<string, unknown>)._fd_id) {
-        return tx.transaction_type === 'FD_MATURITY';
-    }
-    return true;
 };
 
 const TransactionCard: React.FC<TransactionCardProps> = ({ transaction: tx, onEdit, onDelete, onViewDetails }) => {

--- a/frontend/src/components/Transactions/TransactionHistoryTable.tsx
+++ b/frontend/src/components/Transactions/TransactionHistoryTable.tsx
@@ -24,6 +24,40 @@ const getTypeColor = (type: string) => {
     }
 };
 
+const isEditable = (tx: Transaction): boolean => {
+  if (tx.details && (tx.details as Record<string, unknown>)._fd_id) {
+    return false;
+  }
+  if (tx.asset.asset_type === 'PPF' && tx.transaction_type === 'INTEREST_CREDIT') {
+    return false;
+  }
+  return true;
+};
+
+const isDeletable = (tx: Transaction): boolean => {
+  if (tx.asset.asset_type === 'PPF' && tx.transaction_type === 'INTEREST_CREDIT') {
+    return false;
+  }
+  if (tx.details && (tx.details as Record<string, unknown>)._fd_id) {
+    return tx.transaction_type === 'FD_MATURITY';
+  }
+  return true;
+};
+
+const getDisabledTitle = (tx: Transaction, action: 'edit' | 'delete'): string | undefined => {
+  if (tx.asset.asset_type === 'PPF' && tx.transaction_type === 'INTEREST_CREDIT') {
+    return `PPF interest credit transactions are system-generated and cannot be ${action === 'edit' ? 'modified' : 'deleted'}.`;
+  }
+  if (tx.details && (tx.details as Record<string, unknown>)._fd_id) {
+    if (action === 'edit') {
+      return 'Fixed Deposit transactions are system-generated and cannot be modified.';
+    } else if (tx.transaction_type !== 'FD_MATURITY') {
+      return 'Fixed Deposit transactions are system-generated and cannot be deleted.';
+    }
+  }
+  return undefined;
+};
+
 const TransactionHistoryTable: React.FC<TransactionHistoryTableProps> = ({ transactions, onEdit, onDelete }) => {
   const formatCurrency = usePrivacySensitiveCurrency();
   const [selectedTransaction, setSelectedTransaction] = useState<Transaction | null>(null);
@@ -75,7 +109,28 @@ const TransactionHistoryTable: React.FC<TransactionHistoryTableProps> = ({ trans
                                     Number(tx.price_per_unit) * Number(tx.quantity) * (Number(tx.details?.fx_rate) || 1),
                                     'INR'
                                 )}</td>
-                                <td className="p-3 text-center"><div className="flex justify-center space-x-2"><button onClick={() => onEdit(tx)} className="btn btn-secondary btn-sm" aria-label={`Edit ${tx.transaction_type} transaction for ${tx.asset.ticker_symbol}`}>Edit</button><button onClick={() => onDelete(tx)} className="btn btn-danger btn-sm" aria-label={`Delete ${tx.transaction_type} transaction for ${tx.asset.ticker_symbol}`}>Delete</button></div></td>
+                                <td className="p-3 text-center">
+                                    <div className="flex justify-center space-x-2">
+                                        <button
+                                            onClick={() => onEdit(tx)}
+                                            className="btn btn-secondary btn-sm"
+                                            disabled={!isEditable(tx)}
+                                            title={getDisabledTitle(tx, 'edit')}
+                                            aria-label={`Edit ${tx.transaction_type} transaction for ${tx.asset.ticker_symbol}`}
+                                        >
+                                            Edit
+                                        </button>
+                                        <button
+                                            onClick={() => onDelete(tx)}
+                                            className="btn btn-danger btn-sm"
+                                            disabled={!isDeletable(tx)}
+                                            title={getDisabledTitle(tx, 'delete')}
+                                            aria-label={`Delete ${tx.transaction_type} transaction for ${tx.asset.ticker_symbol}`}
+                                        >
+                                            Delete
+                                        </button>
+                                    </div>
+                                </td>
                             </tr>
                         ))}
                     </tbody>

--- a/frontend/src/components/Transactions/TransactionHistoryTable.tsx
+++ b/frontend/src/components/Transactions/TransactionHistoryTable.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Transaction } from '../../types/portfolio';
 import { usePrivacySensitiveCurrency, formatDate } from '../../utils/formatting';
+import { isEditable, isDeletable, getDisabledTitle } from '../../utils/transaction';
 import TransactionDetailsModal from './TransactionDetailsModal';
 import { InformationCircleIcon } from '@heroicons/react/24/outline';
 import TransactionCard from './TransactionCard';
@@ -22,40 +23,6 @@ const getTypeColor = (type: string) => {
         case 'BONUS': return 'text-green-500';
         default: return 'text-gray-600';
     }
-};
-
-const isEditable = (tx: Transaction): boolean => {
-  if (tx.details && (tx.details as Record<string, unknown>)._fd_id) {
-    return false;
-  }
-  if (tx.asset.asset_type === 'PPF' && tx.transaction_type === 'INTEREST_CREDIT') {
-    return false;
-  }
-  return true;
-};
-
-const isDeletable = (tx: Transaction): boolean => {
-  if (tx.asset.asset_type === 'PPF' && tx.transaction_type === 'INTEREST_CREDIT') {
-    return false;
-  }
-  if (tx.details && (tx.details as Record<string, unknown>)._fd_id) {
-    return tx.transaction_type === 'FD_MATURITY';
-  }
-  return true;
-};
-
-const getDisabledTitle = (tx: Transaction, action: 'edit' | 'delete'): string | undefined => {
-  if (tx.asset.asset_type === 'PPF' && tx.transaction_type === 'INTEREST_CREDIT') {
-    return `PPF interest credit transactions are system-generated and cannot be ${action === 'edit' ? 'modified' : 'deleted'}.`;
-  }
-  if (tx.details && (tx.details as Record<string, unknown>)._fd_id) {
-    if (action === 'edit') {
-      return 'Fixed Deposit transactions are system-generated and cannot be modified.';
-    } else if (tx.transaction_type !== 'FD_MATURITY') {
-      return 'Fixed Deposit transactions are system-generated and cannot be deleted.';
-    }
-  }
-  return undefined;
 };
 
 const TransactionHistoryTable: React.FC<TransactionHistoryTableProps> = ({ transactions, onEdit, onDelete }) => {

--- a/frontend/src/utils/transaction.ts
+++ b/frontend/src/utils/transaction.ts
@@ -1,0 +1,35 @@
+import { Transaction } from '../types/portfolio';
+
+export const isEditable = (tx: Transaction): boolean => {
+  if (tx.details && (tx.details as Record<string, unknown>)._fd_id) {
+    return false;
+  }
+  if (tx.asset.asset_type === 'PPF' && tx.transaction_type === 'INTEREST_CREDIT') {
+    return false;
+  }
+  return true;
+};
+
+export const isDeletable = (tx: Transaction): boolean => {
+  if (tx.asset.asset_type === 'PPF' && tx.transaction_type === 'INTEREST_CREDIT') {
+    return false;
+  }
+  if (tx.details && (tx.details as Record<string, unknown>)._fd_id) {
+    return tx.transaction_type === 'FD_MATURITY';
+  }
+  return true;
+};
+
+export const getDisabledTitle = (tx: Transaction, action: 'edit' | 'delete'): string | undefined => {
+  if (tx.asset.asset_type === 'PPF' && tx.transaction_type === 'INTEREST_CREDIT') {
+    return `PPF interest credit transactions are system-generated and cannot be ${action === 'edit' ? 'modified' : 'deleted'}.`;
+  }
+  if (tx.details && (tx.details as Record<string, unknown>)._fd_id) {
+    if (action === 'edit') {
+      return 'Fixed Deposit transactions are system-generated and cannot be modified.';
+    } else if (tx.transaction_type !== 'FD_MATURITY') {
+      return 'Fixed Deposit transactions are system-generated and cannot be deleted.';
+    }
+  }
+  return undefined;
+};


### PR DESCRIPTION
Resolves #440

### Overview
This PR restricts unauthorized modifications or deletions of system-generated PPF interest credit transactions (`INTEREST_CREDIT`) to maintain portfolio integrity.

### Changes
1. **Backend Protection:** Added checks in update/delete endpoints to reject modification requests for `INTEREST_CREDIT` transactions on `PPF` assets with `400 Bad Request`.
2. **Backend Tests:** Added integration tests asserting correct rejection of modification/deletion attempts.
3. **Frontend UI Restrictions:** Disabled or hid "Edit" and "Delete" buttons in the desktop history table, mobile card views, and portfolio transaction list views, including explanatory tooltips where applicable.