### PR TITLE
fix(transactions): adjust sell modal tax lot quantities after corporate actions (#443)

### DIFF
--- a/backend/app/crud/crud_transaction.py
+++ b/backend/app/crud/crud_transaction.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import uuid
 from collections import defaultdict
 from datetime import datetime
@@ -440,7 +441,7 @@ class CRUDTransaction(CRUDBase[Transaction, TransactionCreate, TransactionUpdate
             Transaction.user_id == user_id,
             Transaction.asset_id == asset_id,
             Transaction.transaction_type.in_(
-                ["BUY", "ESPP_PURCHASE", "RSU_VEST", "SELL"]
+                ["BUY", "ESPP_PURCHASE", "RSU_VEST", "SELL", "SPLIT"]
             ),
         )
         if portfolio_id:
@@ -455,9 +456,11 @@ class CRUDTransaction(CRUDBase[Transaction, TransactionCreate, TransactionUpdate
         def get_type_priority(tx_type: str) -> int:
             if tx_type in ["BUY", "ESPP_PURCHASE", "RSU_VEST"]:
                 return 1
-            if tx_type == "SELL":
+            if tx_type == "SPLIT":
                 return 2
-            return 3
+            if tx_type == "SELL":
+                return 3
+            return 4
 
         transactions.sort(key=lambda t: (
             t.transaction_date, get_type_priority(t.transaction_type)
@@ -492,10 +495,41 @@ class CRUDTransaction(CRUDBase[Transaction, TransactionCreate, TransactionUpdate
                 lot = {
                     "transaction": tx,
                     "available_quantity": tx.quantity,
+                    "price_per_unit": tx.price_per_unit,
                     "date": tx.transaction_date,
                 }
                 lots.append(lot)
                 lots_map[tx.id] = lot
+            elif tx.transaction_type == "SPLIT":
+                if tx.price_per_unit > 0:
+                    ratio = tx.quantity / tx.price_per_unit
+
+                    # 1. Calculate total available quantity before split
+                    total_before = sum(lot["available_quantity"] for lot in lots)
+
+                    # 2. Scale each lot's quantity and adjust price per unit
+                    for lot in lots:
+                        lot["available_quantity"] *= ratio
+                        lot["price_per_unit"] /= ratio
+
+                    # 3. Floor total if asset currency is INR and
+                    # deduct fractional difference
+                    asset = crud.asset.get(db=db, id=asset_id)
+                    if asset and asset.currency == "INR":
+                        total_after = total_before * ratio
+                        total_after_floored = Decimal(math.floor(total_after))
+                        fraction = total_after - total_after_floored
+                        if fraction > 0:
+                            remaining_fraction = fraction
+                            for lot in reversed(lots):
+                                if remaining_fraction <= 0:
+                                    break
+                                deduct = min(
+                                    lot["available_quantity"],
+                                    remaining_fraction
+                                )
+                                lot["available_quantity"] -= deduct
+                                remaining_fraction -= deduct
             elif tx.transaction_type == "SELL":
                 # Skip the excluded sell (used during auto-linking)
                 if exclude_sell_id and tx.id == exclude_sell_id:
@@ -537,7 +571,7 @@ class CRUDTransaction(CRUDBase[Transaction, TransactionCreate, TransactionUpdate
                 "id": lot["transaction"].id,
                 "date": lot["date"],
                 "available_quantity": lot["available_quantity"],
-                "price_per_unit": lot["transaction"].price_per_unit,
+                "price_per_unit": lot["price_per_unit"],
                 "type": lot["transaction"].transaction_type,
                 "details": lot["transaction"].details
             }

--- a/backend/app/crud/crud_transaction.py
+++ b/backend/app/crud/crud_transaction.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session, load_only
 
 from app import crud, schemas
 from app.crud.base import CRUDBase
+from app.models.asset import Asset
 from app.models.transaction import Transaction
 from app.models.transaction_link import TransactionLink
 from app.schemas.enums import TransactionType
@@ -436,6 +437,14 @@ class CRUDTransaction(CRUDBase[Transaction, TransactionCreate, TransactionUpdate
                             (used during auto-linking to avoid the new SELL
                             consuming its own lots)
         """
+        # Pre-fetch the asset currency to optimize db lookups inside the loop
+        asset_currency = (
+            db.query(Asset.currency)
+            .filter(Asset.id == asset_id)
+            .limit(1)
+            .scalar()
+        )
+
         # Fetch all relevant transactions sorted by date
         query = db.query(Transaction).filter(
             Transaction.user_id == user_id,
@@ -501,7 +510,7 @@ class CRUDTransaction(CRUDBase[Transaction, TransactionCreate, TransactionUpdate
                 lots.append(lot)
                 lots_map[tx.id] = lot
             elif tx.transaction_type == "SPLIT":
-                if tx.price_per_unit > 0:
+                if tx.price_per_unit > 0 and tx.quantity > 0:
                     ratio = tx.quantity / tx.price_per_unit
 
                     # 1. Calculate total available quantity before split
@@ -514,8 +523,7 @@ class CRUDTransaction(CRUDBase[Transaction, TransactionCreate, TransactionUpdate
 
                     # 3. Floor total if asset currency is INR and
                     # deduct fractional difference
-                    asset = crud.asset.get(db=db, id=asset_id)
-                    if asset and asset.currency == "INR":
+                    if asset_currency == "INR":
                         total_after = total_before * ratio
                         total_after_floored = Decimal(math.floor(total_after))
                         fraction = total_after - total_after_floored

--- a/backend/app/tests/crud/test_tax_lot_accounting_flow.py
+++ b/backend/app/tests/crud/test_tax_lot_accounting_flow.py
@@ -143,3 +143,168 @@ def test_tax_lot_accounting_flow(db: Session):
     # relying on previous sales
     # proves that the system knows what has been sold.
 
+
+def test_tax_lot_split_adjustment(db: Session):
+    # Setup: User
+    user, _ = create_random_user(db)
+
+    # Setup: Portfolio
+    portfolio = crud.portfolio.create_with_owner(
+        db=db,
+        obj_in=schemas.PortfolioCreate(name="Split Test Portfolio"),
+        user_id=user.id
+    )
+
+    # Setup: Asset (USD Stock, so no flooring)
+    asset = crud.asset.create(
+        db=db,
+        obj_in=schemas.AssetCreate(
+            ticker_symbol="SPLITLOT",
+            name="Split Lot Stock",
+            asset_type="STOCK",
+            currency="USD",
+        ),
+    )
+
+    # 1. Buy 10 units @ 100 on D-10
+    buy1 = crud.transaction.create_with_portfolio(
+        db=db,
+        obj_in=schemas.TransactionCreate(
+            asset_id=asset.id,
+            transaction_type="BUY",
+            quantity=10,
+            price_per_unit=100,
+            transaction_date=datetime.now() - timedelta(days=10)
+        ),
+        portfolio_id=portfolio.id
+    )
+
+    # 2. Buy 10 units @ 120 on D-5
+    buy2 = crud.transaction.create_with_portfolio(
+        db=db,
+        obj_in=schemas.TransactionCreate(
+            asset_id=asset.id,
+            transaction_type="BUY",
+            quantity=10,
+            price_per_unit=120,
+            transaction_date=datetime.now() - timedelta(days=5)
+        ),
+        portfolio_id=portfolio.id
+    )
+
+    # 3. Perform a 2-for-1 stock split on D-3
+    crud.crud_corporate_action.handle_stock_split(
+        db=db,
+        portfolio_id=portfolio.id,
+        asset_id=asset.id,
+        transaction_in=schemas.TransactionCreate(
+            asset_id=asset.id,
+            transaction_type="SPLIT",
+            quantity=2,  # New
+            price_per_unit=1,  # Old
+            transaction_date=datetime.now() - timedelta(days=3)
+        )
+    )
+
+    # 4. Check Available Lots
+    lots = crud.transaction.get_available_lots(
+        db=db, asset_id=asset.id, user_id=user.id
+    )
+    assert len(lots) == 2, "Should have 2 available lots"
+    lot1 = next(lot for lot in lots if lot["id"] == buy1.id)
+    lot2 = next(lot for lot in lots if lot["id"] == buy2.id)
+
+    # Verify that quantities are doubled and prices are halved
+    assert float(lot1["available_quantity"]) == 20.0
+    assert float(lot1["price_per_unit"]) == 50.0
+    assert float(lot2["available_quantity"]) == 20.0
+    assert float(lot2["price_per_unit"]) == 60.0
+
+    # 5. Sell 15 units. FIFO should consume from Lot 1 (which now has 20 units)
+    crud.transaction.create_with_portfolio(
+        db=db,
+        obj_in=schemas.TransactionCreate(
+            asset_id=asset.id,
+            transaction_type="SELL",
+            quantity=15,
+            price_per_unit=70,
+            transaction_date=datetime.now()
+        ),
+        portfolio_id=portfolio.id
+    )
+
+    lots_after = crud.transaction.get_available_lots(
+        db=db, asset_id=asset.id, user_id=user.id
+    )
+    lot1_after = next(lot for lot in lots_after if lot["id"] == buy1.id)
+    lot2_after = next(lot for lot in lots_after if lot["id"] == buy2.id)
+
+    # Lot 1 was 20, sold 15 -> 5 remaining
+    assert float(lot1_after["available_quantity"]) == 5.0
+    # Lot 2 remains untouched at 20
+    assert float(lot2_after["available_quantity"]) == 20.0
+
+
+def test_tax_lot_split_inr_flooring(db: Session):
+    # Setup: User
+    user, _ = create_random_user(db)
+
+    # Setup: Portfolio
+    portfolio = crud.portfolio.create_with_owner(
+        db=db,
+        obj_in=schemas.PortfolioCreate(name="Split INR Portfolio"),
+        user_id=user.id
+    )
+
+    # Setup: Asset (INR Stock, floors fractional shares)
+    asset = crud.asset.create(
+        db=db,
+        obj_in=schemas.AssetCreate(
+            ticker_symbol="INRSLOT",
+            name="INR Split Stock",
+            asset_type="STOCK",
+            currency="INR",
+        ),
+    )
+
+    # 1. Buy 1 unit @ 100 on D-10
+    crud.transaction.create_with_portfolio(
+        db=db,
+        obj_in=schemas.TransactionCreate(
+            asset_id=asset.id,
+            transaction_type="BUY",
+            quantity=1,
+            price_per_unit=100,
+            transaction_date=datetime.now() - timedelta(days=10)
+        ),
+        portfolio_id=portfolio.id
+    )
+
+    # 2. Perform a 3:2 stock split on D-5 (3 new for 2 old)
+    # 1 share * 1.5 ratio = 1.5 shares -> floored to 1 share in INR
+    crud.crud_corporate_action.handle_stock_split(
+        db=db,
+        portfolio_id=portfolio.id,
+        asset_id=asset.id,
+        transaction_in=schemas.TransactionCreate(
+            asset_id=asset.id,
+            transaction_type="SPLIT",
+            quantity=3,  # New
+            price_per_unit=2,  # Old
+            transaction_date=datetime.now() - timedelta(days=5)
+        )
+    )
+
+    # 3. Check Available Lots
+    lots = crud.transaction.get_available_lots(
+        db=db, asset_id=asset.id, user_id=user.id
+    )
+    assert len(lots) == 1, "Should have 1 available lot"
+    lot1 = lots[0]
+
+    # Verify that the lot quantity is floored to 1.0 (originally 1.5 before flooring)
+    assert float(lot1["available_quantity"]) == 1.0
+    # Price per unit is adjusted: 100 / 1.5 = 66.6666...
+    assert abs(float(lot1["price_per_unit"]) - (100.0 / 1.5)) < 0.01
+
+

--- a/backend/app/tests/crud/test_tax_lot_accounting_flow.py
+++ b/backend/app/tests/crud/test_tax_lot_accounting_flow.py
@@ -308,3 +308,134 @@ def test_tax_lot_split_inr_flooring(db: Session):
     assert abs(float(lot1["price_per_unit"]) - (100.0 / 1.5)) < 0.01
 
 
+@pytest.mark.usefixtures("pre_unlocked_key_manager")
+def test_tax_lot_reverse_split_adjustment(db: Session):
+    """
+    Test that a reverse stock split (ratio < 1) is correctly applied to tax lots:
+    - INR asset: floors total shares and deducts fractional differences.
+    """
+    # 0. Setup User and Portfolio
+    user, _ = create_random_user(db)
+    portfolio = crud.portfolio.create_with_owner(
+        db=db,
+        obj_in=schemas.PortfolioCreate(name="Test Portfolio"),
+        user_id=user.id
+    )
+
+    # Asset: INR STOCK
+    asset = crud.asset.create(
+        db=db,
+        obj_in=schemas.AssetCreate(
+            ticker_symbol="INR_REV_STOCK",
+            name="INR Reverse Split Stock",
+            asset_type="STOCK",
+            currency="INR",
+        )
+    )
+
+    # 1. Buy 5 units @ 100 on D-10
+    crud.transaction.create_with_portfolio(
+        db=db,
+        obj_in=schemas.TransactionCreate(
+            asset_id=asset.id,
+            transaction_type="BUY",
+            quantity=5,
+            price_per_unit=100,
+            transaction_date=datetime.now() - timedelta(days=10)
+        ),
+        portfolio_id=portfolio.id
+    )
+
+    # 2. Perform a 1:2 reverse stock split on D-5 (1 new for 2 old)
+    crud.crud_corporate_action.handle_stock_split(
+        db=db,
+        portfolio_id=portfolio.id,
+        asset_id=asset.id,
+        transaction_in=schemas.TransactionCreate(
+            asset_id=asset.id,
+            transaction_type="SPLIT",
+            quantity=1,  # New
+            price_per_unit=2,  # Old
+            transaction_date=datetime.now() - timedelta(days=5)
+        )
+    )
+
+    # 3. Check Available Lots
+    lots = crud.transaction.get_available_lots(
+        db=db, asset_id=asset.id, user_id=user.id
+    )
+    assert len(lots) == 1, "Should have 1 available lot"
+    lot1 = lots[0]
+
+    # Verify that the lot quantity is floored: 5 * 0.5 = 2.5 -> floored to 2.0
+    assert float(lot1["available_quantity"]) == 2.0
+    # Price per unit is adjusted: 100 / 0.5 = 200.0
+    assert float(lot1["price_per_unit"]) == 200.0
+
+
+@pytest.mark.usefixtures("pre_unlocked_key_manager")
+def test_tax_lot_reverse_split_usd(db: Session):
+    """
+    Test that a reverse stock split (ratio < 1) for a USD asset
+    retains fractional shares:
+    - USD asset: no flooring applied.
+    """
+    # 0. Setup User and Portfolio
+    user, _ = create_random_user(db)
+    portfolio = crud.portfolio.create_with_owner(
+        db=db,
+        obj_in=schemas.PortfolioCreate(name="Test Portfolio"),
+        user_id=user.id
+    )
+
+    # Asset: USD STOCK
+    asset = crud.asset.create(
+        db=db,
+        obj_in=schemas.AssetCreate(
+            ticker_symbol="USD_REV_STOCK",
+            name="USD Reverse Split Stock",
+            asset_type="STOCK",
+            currency="USD",
+        )
+    )
+
+    # 1. Buy 5 units @ 100 on D-10
+    crud.transaction.create_with_portfolio(
+        db=db,
+        obj_in=schemas.TransactionCreate(
+            asset_id=asset.id,
+            transaction_type="BUY",
+            quantity=5,
+            price_per_unit=100,
+            transaction_date=datetime.now() - timedelta(days=10)
+        ),
+        portfolio_id=portfolio.id
+    )
+
+    # 2. Perform a 1:2 reverse stock split on D-5 (1 new for 2 old)
+    crud.crud_corporate_action.handle_stock_split(
+        db=db,
+        portfolio_id=portfolio.id,
+        asset_id=asset.id,
+        transaction_in=schemas.TransactionCreate(
+            asset_id=asset.id,
+            transaction_type="SPLIT",
+            quantity=1,  # New
+            price_per_unit=2,  # Old
+            transaction_date=datetime.now() - timedelta(days=5)
+        )
+    )
+
+    # 3. Check Available Lots
+    lots = crud.transaction.get_available_lots(
+        db=db, asset_id=asset.id, user_id=user.id
+    )
+    assert len(lots) == 1, "Should have 1 available lot"
+    lot1 = lots[0]
+
+    # Verify that the lot quantity is NOT floored: 5 * 0.5 = 2.5
+    assert float(lot1["available_quantity"]) == 2.5
+    # Price per unit is adjusted: 100 / 0.5 = 200.0
+    assert float(lot1["price_per_unit"]) == 200.0
+
+

--- a/backend/app/tests/crud/test_tax_lot_accounting_flow.py
+++ b/backend/app/tests/crud/test_tax_lot_accounting_flow.py
@@ -143,7 +143,7 @@ def test_tax_lot_accounting_flow(db: Session):
     # relying on previous sales
     # proves that the system knows what has been sold.
 
-
+@pytest.mark.usefixtures("pre_unlocked_key_manager")
 def test_tax_lot_split_adjustment(db: Session):
     # Setup: User
     user, _ = create_random_user(db)
@@ -244,7 +244,7 @@ def test_tax_lot_split_adjustment(db: Session):
     # Lot 2 remains untouched at 20
     assert float(lot2_after["available_quantity"]) == 20.0
 
-
+@pytest.mark.usefixtures("pre_unlocked_key_manager")
 def test_tax_lot_split_inr_flooring(db: Session):
     # Setup: User
     user, _ = create_random_user(db)

--- a/docs/project_handoff_summary.md
+++ b/docs/project_handoff_summary.md
@@ -220,4 +220,4 @@ Based on the `product_backlog.md`, the next features to consider are:
 
 -   **Issue #443:** Fixed tax lots in the Sell modal showing the original purchase quantity instead of the split-adjusted quantity.
 -   **Fix:** Refactored `get_available_lots` in `crud_transaction.py` to replay `SPLIT` transactions chronologically on existing tax lots, adjusting both quantities and prices. Included a flooring mechanism for INR assets to prevent fractional share allocations.
--   **Verification:** Implemented unit/integration tests covering base split quantity/price adjustments, subsequent FIFO matching, and INR flooring. Verified that all 330 backend and 188 frontend tests pass, along with frontend and backend linters.
+-   **Verification:** Implemented unit/integration tests covering base split quantity/price adjustments, subsequent FIFO matching, INR flooring, and reverse stock splits (ratio < 1) for both INR and USD assets to verify flooring and fractional retention behaviors. Verified that all 332 backend and 188 frontend tests pass, along with frontend and backend linters.

--- a/docs/project_handoff_summary.md
+++ b/docs/project_handoff_summary.md
@@ -220,4 +220,8 @@ Based on the `product_backlog.md`, the next features to consider are:
 
 -   **Issue #443:** Fixed tax lots in the Sell modal showing the original purchase quantity instead of the split-adjusted quantity.
 -   **Fix:** Refactored `get_available_lots` in `crud_transaction.py` to replay `SPLIT` transactions chronologically on existing tax lots, adjusting both quantities and prices. Included a flooring mechanism for INR assets to prevent fractional share allocations.
--   **Verification:** Implemented unit/integration tests covering base split quantity/price adjustments, subsequent FIFO matching, INR flooring, and reverse stock splits (ratio < 1) for both INR and USD assets to verify flooring and fractional retention behaviors. Verified that all 332 backend and 188 frontend tests pass, along with frontend and backend linters.
+-   **PR Review & CI/CD Optimizations:**
+    - Pre-fetched asset currency outside the transaction processing loop to optimize database access and avoid N+1 queries.
+    - Added a defensive check (`tx.quantity > 0`) to prevent division by zero in the split ratio calculations.
+    - Applied `@pytest.mark.usefixtures("pre_unlocked_key_manager")` decorators to the first two split tests to resolve KeyManager failures in SQLite encrypted (Desktop) test environments.
+-   **Verification:** Implemented unit/integration tests covering base split quantity/price adjustments, subsequent FIFO matching, INR flooring, and reverse stock splits (ratio < 1) for both INR and USD assets. Verified that all 332 backend and 188 frontend tests pass under all SQLite (encrypted and plain) and PostgreSQL environments, along with linting checks.

--- a/docs/project_handoff_summary.md
+++ b/docs/project_handoff_summary.md
@@ -215,3 +215,9 @@ Based on the `product_backlog.md`, the next features to consider are:
 -   **Vulnerability:** The endpoints lacked the `get_current_user` dependency, allowing unauthenticated access and cross-tenant data exposure.
 -   **Fix:** Added the necessary authentication dependency and ensured that the underlying data queries strictly filter by `user_id` to enforce tenant isolation.
 -   **Service Hardening:** Identified and fixed a secondary data leak in `CapitalGainsService._calculate_demerger_ratios` where buy transactions were missing user-scoping.
+
+## 11. Sell Modal Tax Lot Split Adjustment (2026-06-15)
+
+-   **Issue #443:** Fixed tax lots in the Sell modal showing the original purchase quantity instead of the split-adjusted quantity.
+-   **Fix:** Refactored `get_available_lots` in `crud_transaction.py` to replay `SPLIT` transactions chronologically on existing tax lots, adjusting both quantities and prices. Included a flooring mechanism for INR assets to prevent fractional share allocations.
+-   **Verification:** Implemented unit/integration tests covering base split quantity/price adjustments, subsequent FIFO matching, and INR flooring. Verified that all 330 backend and 188 frontend tests pass, along with frontend and backend linters.

--- a/docs/workflow_history.md
+++ b/docs/workflow_history.md
@@ -1626,3 +1626,26 @@ Resolved all security vulnerabilities related to `tar`, `minimatch`, `rollup`, a
 
 ### Outcome
 **Success.** Successfully closed 16 pending security vulnerability reports from Dependabot.
+
+---
+
+## 2026-06-15: Fix Sell Modal Lot Quantities after Stock Split (#443)
+
+**Task:** Resolve issue where tax lots in the sell modal display the original purchase quantity instead of the split-adjusted quantity after stock splits.
+
+**AI Assistant:** Antigravity
+**Role:** Full-Stack Developer
+
+### Summary
+1. **SPLIT Corporate Action Processing:** Updated `get_available_lots` in `backend/app/crud/crud_transaction.py` to chronologically replay `SPLIT` transactions, scaling the available quantity and price per unit of all existing tax lots before the split.
+2. **INR Flooring:** For Indian Rupees (INR) assets, floored the split-adjusted total quantity to integer values and deducted the fractional difference from the lots (in reverse chronological order) to mirror standard market operations.
+3. **Tests:** Added comprehensive integration tests (`test_tax_lot_split_adjustment` and `test_tax_lot_split_inr_flooring`) in `backend/app/tests/crud/test_tax_lot_accounting_flow.py` to verify correct quantity/price scaling, FIFO matching, and INR flooring behavior.
+
+### File Changes
+
+**Backend:**
+*   **Modified:** `backend/app/crud/crud_transaction.py` - Integrated `SPLIT` transaction processing into `get_available_lots`.
+*   **Modified:** `backend/app/tests/crud/test_tax_lot_accounting_flow.py` - Appended new integration/regression tests for split adjustment and INR flooring.
+
+### Outcome
+**Success.** Tax lots in the Sell modal are now dynamically adjusted for corporate action splits, preventing overselling and ensuring correct cost-basis tracking for subsequent sales.

--- a/docs/workflow_history.md
+++ b/docs/workflow_history.md
@@ -1640,12 +1640,13 @@ Resolved all security vulnerabilities related to `tar`, `minimatch`, `rollup`, a
 1. **SPLIT Corporate Action Processing:** Updated `get_available_lots` in `backend/app/crud/crud_transaction.py` to chronologically replay `SPLIT` transactions, scaling the available quantity and price per unit of all existing tax lots before the split.
 2. **INR Flooring:** For Indian Rupees (INR) assets, floored the split-adjusted total quantity to integer values and deducted the fractional difference from the lots (in reverse chronological order) to mirror standard market operations.
 3. **Tests:** Added comprehensive integration tests (`test_tax_lot_split_adjustment` and `test_tax_lot_split_inr_flooring`) in `backend/app/tests/crud/test_tax_lot_accounting_flow.py` to verify correct quantity/price scaling, FIFO matching, and INR flooring behavior.
+4. **Test Gap Resolution:** Expanded regression testing by adding `test_tax_lot_reverse_split_adjustment` (for INR reverse splits where ratio < 1 with flooring) and `test_tax_lot_reverse_split_usd` (for USD reverse splits retaining fractional shares).
 
 ### File Changes
 
 **Backend:**
 *   **Modified:** `backend/app/crud/crud_transaction.py` - Integrated `SPLIT` transaction processing into `get_available_lots`.
-*   **Modified:** `backend/app/tests/crud/test_tax_lot_accounting_flow.py` - Appended new integration/regression tests for split adjustment and INR flooring.
+*   **Modified:** `backend/app/tests/crud/test_tax_lot_accounting_flow.py` - Appended new integration/regression tests for split adjustment, INR flooring, and reverse splits.
 
 ### Outcome
-**Success.** Tax lots in the Sell modal are now dynamically adjusted for corporate action splits, preventing overselling and ensuring correct cost-basis tracking for subsequent sales.
+**Success.** Tax lots in the Sell modal are now dynamically adjusted for corporate action splits and reverse splits, preventing overselling and ensuring correct cost-basis tracking for subsequent sales. All backend (SQLite/Postgres) and frontend test suites pass.

--- a/docs/workflow_history.md
+++ b/docs/workflow_history.md
@@ -1641,12 +1641,16 @@ Resolved all security vulnerabilities related to `tar`, `minimatch`, `rollup`, a
 2. **INR Flooring:** For Indian Rupees (INR) assets, floored the split-adjusted total quantity to integer values and deducted the fractional difference from the lots (in reverse chronological order) to mirror standard market operations.
 3. **Tests:** Added comprehensive integration tests (`test_tax_lot_split_adjustment` and `test_tax_lot_split_inr_flooring`) in `backend/app/tests/crud/test_tax_lot_accounting_flow.py` to verify correct quantity/price scaling, FIFO matching, and INR flooring behavior.
 4. **Test Gap Resolution:** Expanded regression testing by adding `test_tax_lot_reverse_split_adjustment` (for INR reverse splits where ratio < 1 with flooring) and `test_tax_lot_reverse_split_usd` (for USD reverse splits retaining fractional shares).
+5. **PR Review Optimizations & CI Fixes:**
+    - Optimized database access by pre-fetching the asset currency outside the transaction loop in `get_available_lots`.
+    - Added a defensive check (`tx.quantity > 0`) to prevent a division-by-zero error on split ratio calculations.
+    - Added `@pytest.mark.usefixtures("pre_unlocked_key_manager")` decorators to the first two split tests to resolve key-manager SQLite encryption failures in the CI/CD pipeline.
 
 ### File Changes
 
 **Backend:**
-*   **Modified:** `backend/app/crud/crud_transaction.py` - Integrated `SPLIT` transaction processing into `get_available_lots`.
-*   **Modified:** `backend/app/tests/crud/test_tax_lot_accounting_flow.py` - Appended new integration/regression tests for split adjustment, INR flooring, and reverse splits.
+*   **Modified:** `backend/app/crud/crud_transaction.py` - Integrated optimized `SPLIT` transaction processing into `get_available_lots`.
+*   **Modified:** `backend/app/tests/crud/test_tax_lot_accounting_flow.py` - Appended new integration/regression tests and decorated existing split tests.
 
 ### Outcome
-**Success.** Tax lots in the Sell modal are now dynamically adjusted for corporate action splits and reverse splits, preventing overselling and ensuring correct cost-basis tracking for subsequent sales. All backend (SQLite/Postgres) and frontend test suites pass.
+**Success.** Tax lots in the Sell modal are now dynamically adjusted for corporate action splits and reverse splits, preventing overselling and ensuring correct cost-basis tracking for subsequent sales. Database performance has been optimized, division-by-zero checks are in place, and SQLite encrypted test environments (Desktop) pass without KeyManager failures.


### PR DESCRIPTION
Closes #443. This PR implements dynamic tax lot adjustments following corporate action splits (and reverse splits) in the Sell modal, including currency-specific flooring for INR assets.