### PR TITLE
🎨 Palette: Add aria-hidden to decorative icons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,7 @@
 ## $(date +%Y-%m-%d) - Improve empty states for transaction lists
 **Learning:** Simple text empty states feel unpolished and don't provide a good visual cue for users when there is no data.
 **Action:** Replaced plain text empty states in `TransactionHistoryTable` and `TransactionList` with a standard empty state component using a Heroicon (`ListBulletIcon`), a heading, and helpful guidance text, matching the pattern established in the `WatchlistTable` component.
+
+## $(date +%Y-%m-%d) - Adding aria-hidden to decorative icons
+**Learning:** Decorative SVG icons (like Heroicons used inside buttons that already have `aria-label`s or adjacent text) were being redundantly parsed or announced by screen readers because they lacked `aria-hidden="true"`.
+**Action:** When adding or updating icon-only buttons or icons next to text, explicitly add `aria-hidden="true"` to the SVG component if the parent element already provides an accessible name (e.g., via `aria-label`).

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ local/*
 
 .gemini/
 gha-creds-*.json
+backend/*.db*

--- a/frontend/src/components/Admin/AliasCard.tsx
+++ b/frontend/src/components/Admin/AliasCard.tsx
@@ -18,10 +18,10 @@ const AliasCard: React.FC<AliasCardProps> = ({ alias, onEdit, onDelete }) => {
                 </div>
                 <div className="flex items-center gap-1">
                     <button onClick={() => onEdit(alias)} className="p-2 text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors" aria-label="Edit alias">
-                        <PencilIcon className="h-4 w-4" />
+                        <PencilIcon className="h-4 w-4" aria-hidden="true" />
                     </button>
                     <button onClick={() => onDelete(alias)} className="p-2 text-gray-500 hover:text-red-600 dark:hover:text-red-400 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors" aria-label="Delete alias">
-                        <TrashIcon className="h-4 w-4" />
+                        <TrashIcon className="h-4 w-4" aria-hidden="true" />
                     </button>
                 </div>
             </div>

--- a/frontend/src/components/Admin/InterestRateCard.tsx
+++ b/frontend/src/components/Admin/InterestRateCard.tsx
@@ -23,10 +23,10 @@ const InterestRateCard: React.FC<InterestRateCardProps> = ({ rate, onEdit, onDel
                 </div>
                 <div className="flex items-center gap-1">
                     <button onClick={() => onEdit(rate)} className="p-2 text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors" aria-label={`Edit rate for ${rate.scheme_name}`}>
-                        <PencilSquareIcon className="h-5 w-5" />
+                        <PencilSquareIcon className="h-5 w-5" aria-hidden="true" />
                     </button>
                     <button onClick={() => onDelete(rate)} className="p-2 text-gray-500 hover:text-red-600 dark:hover:text-red-400 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors" aria-label={`Delete rate for ${rate.scheme_name}`}>
-                        <TrashIcon className="h-5 w-5" />
+                        <TrashIcon className="h-5 w-5" aria-hidden="true" />
                     </button>
                 </div>
             </div>

--- a/frontend/src/components/Admin/InterestRateTable.tsx
+++ b/frontend/src/components/Admin/InterestRateTable.tsx
@@ -35,10 +35,10 @@ const InterestRateTable: React.FC<InterestRateTableProps> = ({ rates, onEdit, on
                             <td className="p-3">
                                 <div className="flex justify-center items-center space-x-4">
                                     <button onClick={() => onEdit(rate)} className="text-gray-500 hover:text-blue-600" aria-label={`Edit rate for ${rate.scheme_name}`}>
-                                        <PencilSquareIcon className="h-5 w-5" />
+                                        <PencilSquareIcon className="h-5 w-5" aria-hidden="true" />
                                     </button>
                                     <button onClick={() => onDelete(rate)} className="text-gray-500 hover:text-red-600" aria-label={`Delete rate for ${rate.scheme_name}`}>
-                                        <TrashIcon className="h-5 w-5" />
+                                        <TrashIcon className="h-5 w-5" aria-hidden="true" />
                                     </button>
                                 </div>
                             </td>

--- a/frontend/src/components/Admin/UsersTable.tsx
+++ b/frontend/src/components/Admin/UsersTable.tsx
@@ -34,10 +34,10 @@ const UsersTable: React.FC<UsersTableProps> = ({ users, onEdit, onDelete }) => {
                             <td className="text-right py-3 px-4">
                                 <div className="flex justify-end items-center space-x-4">
                                     <button type="button" onClick={() => onEdit(user)} className="text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 transition-colors" aria-label={`Edit user ${user.email}`} title="Edit User">
-                                        <PencilSquareIcon className="h-5 w-5" />
+                                        <PencilSquareIcon className="h-5 w-5" aria-hidden="true" />
                                     </button>
                                     <button type="button" onClick={() => onDelete(user)} className="text-gray-500 hover:text-red-600 dark:hover:text-red-400 transition-colors" aria-label={`Delete user ${user.email}`} title="Delete User">
-                                        <TrashIcon className="h-5 w-5" />
+                                        <TrashIcon className="h-5 w-5" aria-hidden="true" />
                                     </button>
                                 </div>
                             </td>

--- a/frontend/src/components/Goals/GoalDetailView.tsx
+++ b/frontend/src/components/Goals/GoalDetailView.tsx
@@ -206,7 +206,7 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({ goalId }) => {
           <div className="flex justify-between items-center">
             <h2 className="card-title dark:text-gray-100">Linked Items</h2>
             <button onClick={() => setIsLinkModalOpen(true)} className="btn btn-secondary btn-sm">
-              <LinkIcon className="h-5 w-5 mr-2" />
+              <LinkIcon className="h-5 w-5 mr-2" aria-hidden="true" />
               Link Item
             </button>
           </div>
@@ -222,7 +222,7 @@ const GoalDetailView: React.FC<GoalDetailViewProps> = ({ goalId }) => {
                   className="btn btn-ghost btn-sm text-red-500 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/30"
                   disabled={deleteGoalLink.isPending}
                 >
-                  <TrashIcon className="h-5 w-5" />
+                  <TrashIcon className="h-5 w-5" aria-hidden="true" />
                 </button>
               </div>
             )) : (

--- a/frontend/src/components/Goals/GoalList.tsx
+++ b/frontend/src/components/Goals/GoalList.tsx
@@ -68,7 +68,7 @@ const GoalList: React.FC<GoalListProps> = ({ goals }) => {
                     disabled={deleteGoalMutation.isPending && goalToDelete?.id === goal.id}
                     aria-label={`Delete ${goal.name}`}
                   >
-                    <TrashIcon className="h-5 w-5" />
+                    <TrashIcon className="h-5 w-5" aria-hidden="true" />
                   </button>
                 </div>
               </div>

--- a/frontend/src/components/MobileNav.tsx
+++ b/frontend/src/components/MobileNav.tsx
@@ -30,7 +30,7 @@ const MobileNav: React.FC = () => {
                 </NavLink>
 
                 <NavLink to="/transactions" className={({ isActive }) => linkClass(isActive)}>
-                    <ListBulletIcon className="h-6 w-6" />
+                    <ListBulletIcon className="h-6 w-6" aria-hidden="true" />
                     <span className="text-[10px] mt-1 font-medium">History</span>
                 </NavLink>
 

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -98,7 +98,7 @@ const NavBar: React.FC = () => {
                     to="/transactions"
                     className={({ isActive }) => linkClass(isActive)}
                 >
-                    <ListBulletIcon className="h-5 w-5" />
+                    <ListBulletIcon className="h-5 w-5" aria-hidden="true" />
                     <span>Transactions</span>
                 </NavLink>
                 <NavLink
@@ -155,7 +155,7 @@ const NavBar: React.FC = () => {
                             <span>FMV Management</span>
                         </NavLink>
                         <NavLink to="/admin/aliases" className={({ isActive }) => linkClass(isActive)}>
-                            <ListBulletIcon className="h-5 w-5" />
+                            <ListBulletIcon className="h-5 w-5" aria-hidden="true" />
                             <span>Symbol Aliases</span>
                         </NavLink>
                     </>

--- a/frontend/src/components/Portfolio/BondDetailModal.tsx
+++ b/frontend/src/components/Portfolio/BondDetailModal.tsx
@@ -43,7 +43,7 @@ const BondDetailModal: React.FC<BondDetailModalProps> = ({
                         <p className="text-sm text-gray-500 dark:text-gray-400">{holding.isin}</p>
                     </div>
                     <button aria-label="Close" onClick={onClose} className="text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:hover:text-gray-200 dark:hover:bg-gray-700 rounded-full w-8 h-8 flex items-center justify-center transition-colors -mr-2 -mt-2">
-                        <XMarkIcon className="h-6 w-6" />
+                        <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                     </button>
                 </div>
 
@@ -104,8 +104,8 @@ const BondDetailModal: React.FC<BondDetailModalProps> = ({
                                         <td className="p-2 text-right font-mono dark:text-gray-200">{formatCurrency(Number(tx.quantity) * Number(tx.price_per_unit))}</td>
                                         <td className="p-2 text-center">
                                             <div className="flex items-center justify-center space-x-3">
-                                                <button aria-label={`Edit transaction for ${holding.asset_name}`} onClick={() => onEditTransaction(tx)} className="text-gray-500 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400" title="Edit Transaction"><PencilSquareIcon className="h-5 w-5" /></button>
-                                                <button aria-label={`Delete transaction for ${holding.asset_name}`} onClick={() => onDeleteTransaction(tx)} className="text-gray-500 hover:text-red-600 dark:text-gray-400 dark:hover:text-red-400" title="Delete Transaction"><TrashIcon className="h-5 w-5" /></button>
+                                                <button aria-label={`Edit transaction for ${holding.asset_name}`} onClick={() => onEditTransaction(tx)} className="text-gray-500 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400" title="Edit Transaction"><PencilSquareIcon className="h-5 w-5" aria-hidden="true" /></button>
+                                                <button aria-label={`Delete transaction for ${holding.asset_name}`} onClick={() => onDeleteTransaction(tx)} className="text-gray-500 hover:text-red-600 dark:text-gray-400 dark:hover:text-red-400" title="Delete Transaction"><TrashIcon className="h-5 w-5" aria-hidden="true" /></button>
                                             </div>
                                         </td>
                                     </tr>

--- a/frontend/src/components/Portfolio/FixedDepositDetailModal.tsx
+++ b/frontend/src/components/Portfolio/FixedDepositDetailModal.tsx
@@ -42,7 +42,7 @@ const FixedDepositDetailModal: React.FC<FixedDepositDetailModalProps> = ({ holdi
                 <div className="flex justify-between items-center mb-4">
                     <h2 className="text-2xl font-bold dark:text-gray-100">Holding Detail: {holding.asset_name}</h2>
                     <button aria-label="Close" onClick={onClose} className="text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:hover:text-gray-200 dark:hover:bg-gray-700 rounded-full w-8 h-8 flex items-center justify-center transition-colors -mr-2 -mt-2">
-                        <XMarkIcon className="h-6 w-6" />
+                        <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                     </button>
                 </div>
 

--- a/frontend/src/components/Portfolio/HoldingDetailModal.tsx
+++ b/frontend/src/components/Portfolio/HoldingDetailModal.tsx
@@ -79,10 +79,10 @@ const TransactionRow: React.FC<TransactionRowProps> = ({ transaction, currentPri
             <td className="p-2 text-right">
                 <div className="flex items-center justify-end space-x-3">
                     <button onClick={() => onEdit(transaction)} className="text-gray-500 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400" title="Edit Transaction" aria-label="Edit transaction">
-                        <PencilSquareIcon className="h-5 w-5" />
+                        <PencilSquareIcon className="h-5 w-5" aria-hidden="true" />
                     </button>
                     <button onClick={() => onDelete(transaction)} className="text-gray-500 hover:text-red-600 dark:text-gray-400 dark:hover:text-red-400" title="Delete Transaction" aria-label="Delete transaction">
-                        <TrashIcon className="h-5 w-5" />
+                        <TrashIcon className="h-5 w-5" aria-hidden="true" />
                     </button>
                 </div>
             </td>
@@ -186,7 +186,7 @@ const HoldingDetailModal: React.FC<HoldingDetailModalProps> = ({ holding, portfo
                         <p className="text-sm text-gray-500 dark:text-gray-400">Current Holdings Breakdown</p>
                     </div>
                     <button aria-label="Close" onClick={onClose} className="text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:hover:text-gray-200 dark:hover:bg-gray-700 rounded-full w-8 h-8 flex items-center justify-center transition-colors -mr-2 -mt-2">
-                        <XMarkIcon className="h-6 w-6" />
+                        <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                     </button>
                 </div>
 

--- a/frontend/src/components/Portfolio/PortfolioList.tsx
+++ b/frontend/src/components/Portfolio/PortfolioList.tsx
@@ -51,7 +51,7 @@ const PortfolioList: React.FC<PortfolioListProps> = ({ portfolios }) => {
                             className="btn btn-sm btn-ghost text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/30"
                             disabled={deletePortfolioMutation.isPending}
                             aria-label={`Delete portfolio ${portfolio.name}`}>
-                            <TrashIcon className="h-5 w-5" />
+                            <TrashIcon className="h-5 w-5" aria-hidden="true" />
                         </button>
                     </div>
                 ))}

--- a/frontend/src/components/Portfolio/PpfHoldingDetailModal.tsx
+++ b/frontend/src/components/Portfolio/PpfHoldingDetailModal.tsx
@@ -150,7 +150,7 @@ const PpfHoldingDetailModal: React.FC<PpfHoldingDetailModalProps> = ({
                           aria-label="Edit transaction"
                           onClick={() => onEdit(tx)}
                         >
-                          <PencilSquareIcon className="h-5 w-5" />
+                          <PencilSquareIcon className="h-5 w-5" aria-hidden="true" />
                         </button>
                         <button
                           className="text-gray-500 hover:text-red-600 dark:text-gray-400 dark:hover:text-red-400"
@@ -158,7 +158,7 @@ const PpfHoldingDetailModal: React.FC<PpfHoldingDetailModalProps> = ({
                           aria-label="Delete transaction"
                           onClick={() => onDelete(tx)}
                         >
-                          <TrashIcon className="h-5 w-5" />
+                          <TrashIcon className="h-5 w-5" aria-hidden="true" />
                         </button>
                       </div>
                     ) : (

--- a/frontend/src/components/Portfolio/RecurringDepositDetailModal.tsx
+++ b/frontend/src/components/Portfolio/RecurringDepositDetailModal.tsx
@@ -24,7 +24,7 @@ const RecurringDepositDetailModal: React.FC<RecurringDepositDetailModalProps> = 
                 <div className="flex justify-between items-center mb-4">
                     <h2 className="text-2xl font-bold dark:text-gray-100">Holding Detail: {holding.asset_name}</h2>
                     <button aria-label="Close" onClick={onClose} className="text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:hover:text-gray-200 dark:hover:bg-gray-700 rounded-full w-8 h-8 flex items-center justify-center transition-colors -mr-2 -mt-2">
-                        <XMarkIcon className="h-6 w-6" />
+                        <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                     </button>
                 </div>
 

--- a/frontend/src/components/Portfolio/TransactionList.tsx
+++ b/frontend/src/components/Portfolio/TransactionList.tsx
@@ -86,7 +86,7 @@ const TransactionList: React.FC<TransactionListProps> = ({ transactions, onEdit,
                       title={getDisabledTitle(tx, 'edit')}
                       aria-label={`Edit transaction for ${tx.asset.ticker_symbol}`}
                     >
-                      <PencilSquareIcon className="h-5 w-5" />
+                      <PencilSquareIcon className="h-5 w-5" aria-hidden="true" />
                     </button>
                     <button
                       onClick={() => onDelete(tx)}
@@ -95,7 +95,7 @@ const TransactionList: React.FC<TransactionListProps> = ({ transactions, onEdit,
                       title={getDisabledTitle(tx, 'delete')}
                       aria-label={`Delete transaction for ${tx.asset.ticker_symbol}`}
                     >
-                      <TrashIcon className="h-5 w-5" />
+                      <TrashIcon className="h-5 w-5" aria-hidden="true" />
                     </button>
                   </div>
                 </td>

--- a/frontend/src/components/Transactions/TransactionCard.tsx
+++ b/frontend/src/components/Transactions/TransactionCard.tsx
@@ -63,7 +63,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({ transaction: tx, onEd
                             onClick={() => onViewDetails(tx)}
                             className="text-blue-500 hover:text-blue-700 mt-2 flex items-center gap-1 text-[10px] font-medium"
                         >
-                            <InformationCircleIcon className="h-4 w-4" />
+                            <InformationCircleIcon className="h-4 w-4" aria-hidden="true" />
                             Details
                         </button>
                     )}
@@ -91,7 +91,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({ transaction: tx, onEd
                             className="p-2 text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                             aria-label="Edit transaction"
                         >
-                            <PencilIcon className="h-5 w-5" />
+                            <PencilIcon className="h-5 w-5" aria-hidden="true" />
                         </button>
                     )}
                     {isDeletable(tx) && (
@@ -100,7 +100,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({ transaction: tx, onEd
                             className="p-2 text-gray-500 hover:text-red-600 dark:hover:text-red-400 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                             aria-label="Delete transaction"
                         >
-                            <TrashIcon className="h-5 w-5" />
+                            <TrashIcon className="h-5 w-5" aria-hidden="true" />
                         </button>
                     )}
                 </div>

--- a/frontend/src/components/Transactions/TransactionHistoryTable.tsx
+++ b/frontend/src/components/Transactions/TransactionHistoryTable.tsx
@@ -72,7 +72,7 @@ const TransactionHistoryTable: React.FC<TransactionHistoryTableProps> = ({ trans
                                             title="View Details"
                                             aria-label="View details"
                                         >
-                                            <InformationCircleIcon className="h-5 w-5" />
+                                            <InformationCircleIcon className="h-5 w-5" aria-hidden="true" />
                                         </button>
                                     )}
                                 </td>

--- a/frontend/src/components/Watchlists/WatchlistItemCard.tsx
+++ b/frontend/src/components/Watchlists/WatchlistItemCard.tsx
@@ -35,7 +35,7 @@ const WatchlistItemCard: React.FC<WatchlistItemCardProps> = ({ item, watchlistId
                     className="p-2 text-gray-400 hover:text-red-600 dark:hover:text-red-400 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                     aria-label={`Remove ${item.asset.ticker_symbol}`}
                 >
-                    <TrashIcon className="h-5 w-5" />
+                    <TrashIcon className="h-5 w-5" aria-hidden="true" />
                 </button>
             </div>
 

--- a/frontend/src/components/Watchlists/WatchlistSelector.tsx
+++ b/frontend/src/components/Watchlists/WatchlistSelector.tsx
@@ -75,7 +75,7 @@ const WatchlistSelector: React.FC<WatchlistSelectorProps> = ({
       <div className="flex justify-between items-center mb-2">
         <h2 className="text-lg font-bold">My Watchlists</h2>
         <button className="btn btn-sm btn-primary" onClick={handleCreate} aria-label="Add new watchlist">
-          <PlusIcon className="h-4 w-4" />
+          <PlusIcon className="h-4 w-4" aria-hidden="true" />
         </button>
       </div>
       <ul className="menu bg-base-100 rounded-box">
@@ -103,7 +103,7 @@ const WatchlistSelector: React.FC<WatchlistSelectorProps> = ({
                   }}
                   aria-label={`Edit ${watchlist.name}`}
                 >
-                  <PencilIcon className="h-4 w-4" />
+                  <PencilIcon className="h-4 w-4" aria-hidden="true" />
                 </button>
                 <button
                   className="btn btn-ghost btn-xs"
@@ -113,7 +113,7 @@ const WatchlistSelector: React.FC<WatchlistSelectorProps> = ({
                   }}
                   aria-label={`Delete ${watchlist.name}`}
                 >
-                  <TrashIcon className="h-4 w-4 text-red-500" />
+                  <TrashIcon className="h-4 w-4 text-red-500" aria-hidden="true" />
                 </button>
               </div>
             </a>

--- a/frontend/src/components/Watchlists/WatchlistTable.tsx
+++ b/frontend/src/components/Watchlists/WatchlistTable.tsx
@@ -50,7 +50,7 @@ const WatchlistTable: React.FC<WatchlistTableProps> = ({ watchlist, isLoading, e
   if (!watchlist || watchlist.items.length === 0) {
     return (
       <div className="text-center p-8">
-        <ListBulletIcon className="mx-auto h-12 w-12 text-gray-400" />
+        <ListBulletIcon className="mx-auto h-12 w-12 text-gray-400" aria-hidden="true" />
         <h3 className="mt-2 text-lg font-medium text-gray-900 dark:text-white">This watchlist is empty</h3>
         <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">Add assets to start tracking.</p>
       </div>
@@ -87,7 +87,7 @@ const WatchlistTable: React.FC<WatchlistTableProps> = ({ watchlist, isLoading, e
                     className="btn btn-ghost btn-xs text-gray-400 hover:text-red-500"
                     aria-label={`Remove ${item.asset.ticker_symbol}`}
                   >
-                    <TrashIcon className="h-4 w-4" />
+                    <TrashIcon className="h-4 w-4" aria-hidden="true" />
                   </button>
                 </td>
               </tr>

--- a/frontend/src/components/common/Toast.tsx
+++ b/frontend/src/components/common/Toast.tsx
@@ -30,7 +30,7 @@ const Toast: React.FC<ToastProps> = ({ message, type, onClose }) => {
         className="ml-2 p-1 hover:bg-white/20 rounded-full focus:outline-none focus:ring-2 focus:ring-white/50 transition-colors"
         aria-label="Close notification"
       >
-        <XMarkIcon className="h-5 w-5" />
+        <XMarkIcon className="h-5 w-5" aria-hidden="true" />
       </button>
     </div>
   );

--- a/frontend/src/components/modals/AddAssetToWatchlistModal.tsx
+++ b/frontend/src/components/modals/AddAssetToWatchlistModal.tsx
@@ -77,7 +77,7 @@ const AddAssetToWatchlistModal: React.FC<AddAssetToWatchlistModalProps> = ({
             className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
             aria-label="Close"
           >
-            <XMarkIcon className="h-6 w-6" />
+            <XMarkIcon className="h-6 w-6" aria-hidden="true" />
           </button>
         </div>
 
@@ -133,7 +133,7 @@ const AddAssetToWatchlistModal: React.FC<AddAssetToWatchlistModalProps> = ({
                 aria-label="Clear selection"
                 disabled={isAdding}
               >
-                <XMarkIcon className="h-5 w-5" />
+                <XMarkIcon className="h-5 w-5" aria-hidden="true" />
               </button>
             </div>
           )}


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to decorative SVG icons (Heroicons) used within buttons across multiple components.
🎯 Why: Prevents screen readers from redundantly announcing or parsing SVG paths for icons when the parent button already has an accessible name (via `aria-label` or text).
📸 Before/After: Visuals remain identical.
♿ Accessibility: Improves screen reader experience by hiding purely decorative UI elements.

---
*PR created automatically by Jules for task [6965448180101111549](https://jules.google.com/task/6965448180101111549) started by @aashishbhanawat*